### PR TITLE
fix: remove logo from product since brand already has it

### DIFF
--- a/schema/Product.schema.yaml
+++ b/schema/Product.schema.yaml
@@ -12,11 +12,6 @@ allOf:
       type: object
       items:
         $ref: Brand.schema.yaml
-  - logo:
-       '@id': schema:logo
-       type: object
-       items:
-          $ref: ImageObject.schema.yaml
   - productID:
       '@id': schema:productID
       type: string


### PR DESCRIPTION
My over-diligence bites back. Since `product` has a property `brand` which includes `logo`, product itself doesn't need it.