### PR TITLE
fix: typo in Organization and removed logo and owns

### DIFF
--- a/schema/Organization.schema.md
+++ b/schema/Organization.schema.md
@@ -2,7 +2,7 @@
 
 ## Extends
 
-`ContactPoint` extends `Thing`.
+`Organization` extends `Thing`.
 
 ## Related
 

--- a/schema/Organization.schema.yaml
+++ b/schema/Organization.schema.yaml
@@ -37,15 +37,3 @@ allOf:
       legalName:
         '@id': schema:legalName
         type: string
-      logo:
-        '@id': schema:logo
-        type: array
-        items:
-          anyOf:
-            - $ref: URL.schema.yaml
-            - $ref: ImageObject.schema.yaml
-      owns:
-        '@id': schema:owns
-        type: array
-        items:
-          $ref: Product.schema.yaml


### PR DESCRIPTION
Another refinement:
* Organization already has `brand` so no need for `logo`
* `owns` removed as discussed earlier today

Plus a typo fix