### PR TITLE
Updates, most around Datatables, necessary for converter

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -170,8 +170,7 @@ async function typescript() {
 /**
  * This file was automatically generated.
  * Do not modify it by hand. Instead, modify the source \`.schema.yaml\` file
- * in the \`schema\` directory and run \`npm run build\`
- * to regenerate this file.
+ * in the \`schema\` directory and run \`npm run build\` to regenerate this file.
  */`
   }
   const ts = await jstt.compileFromFile(src, options)

--- a/examples/datatables/simple.datatable.yaml
+++ b/examples/datatables/simple.datatable.yaml
@@ -3,10 +3,16 @@ columns:
   - type: DatatableColumn
     name: A
     schema:
-      type: number
+      type: DatatableColumnSchema
+      items:
+        type: number
     values:
       - 1
       - 2
       - 3
   - type: DatatableColumn
     name: B
+    values:
+      - 4
+      - 5
+      - 6

--- a/schema/Article.schema.yaml
+++ b/schema/Article.schema.yaml
@@ -1,0 +1,12 @@
+$schema: http://json-schema.org/draft-07/schema#
+$id: https://stencila.github.com/schema/Article.schema.json
+title: Article
+'@id': schema:Article
+allOf:
+  - $ref: CreativeWork.schema.yaml
+  - properties:
+      content:
+        '@id': stencila:content
+        type: array
+        items:
+          $ref: Node.schema.yaml

--- a/schema/Collection.schema.yaml
+++ b/schema/Collection.schema.yaml
@@ -1,0 +1,18 @@
+$schema: http://json-schema.org/draft-07/schema#
+$id: https://stencila.github.com/schema/Collection.schema.json
+title: Collection
+'@id': schema:Collection
+allOf:
+  - $ref: CreativeWork.schema.yaml
+  - properties:
+      type:
+        type: string
+        enum: [Collection]
+      parts:
+        '@id': schema:hasParts
+        type: array
+        items:
+          $ref: CreativeWork.schema.yaml
+required:
+  - type
+  - parts

--- a/schema/CreativeWork.schema.yaml
+++ b/schema/CreativeWork.schema.yaml
@@ -22,3 +22,11 @@ allOf:
           anyOf:
             - type: string
             - $ref: CreativeWork.schema.yaml
+      licenses:
+        '@id': schema:license
+        description: License documents that applies to this content, typically indicated by URL.
+        type: array
+        items:
+          anyOf:
+            - $ref: URL.schema.yaml
+            - $ref: CreativeWork.schema.yaml

--- a/schema/Node.schema.yaml
+++ b/schema/Node.schema.yaml
@@ -1,0 +1,15 @@
+$schema: http://json-schema.org/draft-07/schema#
+$id: https://stencila.github.com/schema/Node.schema.json
+'@id': stencila:Node
+title: Node
+description: |
+  Describes a valid value for any node in the tree.
+anyOf:
+  - type: 'null'
+  - type: boolean
+  - type: number
+  - type: integer
+  - type: string
+  - type: array
+  - type: object
+  - $ref: Thing.schema.yaml

--- a/schema/Thing.schema.yaml
+++ b/schema/Thing.schema.yaml
@@ -5,9 +5,12 @@ title: Thing
 description: The most generic type of item https://schema.org/Thing.
 type: object
 properties:
-  type:
-    description: The type of node.
-    type: string
+  alternateNames:
+    '@id': schema:alternateName
+    description: Alternate names (aliases) for the item.
+    type: array
+    items:
+      type: string
   description:
     '@id': schema:description
     description: A description of the item.
@@ -15,7 +18,6 @@ properties:
   name:
     '@id': schema:name
     description: The name of the item.
-    allOf:
-      - $ref: name.schema.yaml
+    type: string
 required:
   - type

--- a/schema/data/Datatable.md
+++ b/schema/data/Datatable.md
@@ -1,0 +1,7 @@
+## Related
+
+### Frictionless Data Tabular Data Package
+
+The Tabular Data Package defines data in a similar format to what the Stencila schema describes however it is designed to be used with a schema/data definition in one file, and the data in its own CSV file. A `path` property in the data definition file is used to record this relationship.
+
+The Stencila schema stores data in separate DatatableColumns, where each DataTableColumn should have its own schema.

--- a/schema/data/Datatable.schema.yaml
+++ b/schema/data/Datatable.schema.yaml
@@ -7,9 +7,14 @@ type: object
 allOf:
   - $ref: CreativeWork.schema.yaml
   - properties:
+      type:
+        type: string
+        enum: [Datatable]
       columns:
         description: TODO
         type: array
         items:
           $ref: DatatableColumn.schema.yaml
-value: columns
+required:
+  - type
+  - columns

--- a/schema/data/DatatableColumn.schema.yaml
+++ b/schema/data/DatatableColumn.schema.yaml
@@ -16,10 +16,11 @@ allOf:
         description: The schema to use to validate data in the column.
         type: object
         allOf:
-          - $ref: json-schema-draft-07.schema.json
+          - $ref: DatatableColumnSchema.schema.yaml
       values:
         description: The values of the column.
         type: array
 value: values
 required:
   - name
+  - values

--- a/schema/data/DatatableColumnSchema.schema.yaml
+++ b/schema/data/DatatableColumnSchema.schema.yaml
@@ -1,0 +1,17 @@
+$schema: http://json-schema.org/draft-07/schema#
+$id: https://stencila.github.com/schema/DatatableColumnSchema.schema.json
+title: DatatableColumnSchema
+'@id': stencila:DatatableColumnSchema
+properties:
+  type:
+    type: string
+    enum: [DatatableColumnSchema]
+  items:
+    type: object
+    allOf:
+      - $ref: json-schema-draft-07.schema.json
+  uniqueItems:
+    type: boolean
+    default: false
+required:
+  - type

--- a/schema/index.schema.yaml
+++ b/schema/index.schema.yaml
@@ -2,10 +2,13 @@ $schema: http://json-schema.org/draft-07/schema#
 $id: https://stencila.github.com/schema/index.schema.json
 '@id': stencila:index
 anyOf:
+  - $ref: Article.schema.yaml
   - $ref: Brand.schema.yaml
+  - $ref: Blockquote.schema.yaml
   - $ref: ContactPoint.schema.yaml
   - $ref: CodeChunk.schema.yaml
   - $ref: CodeChunkMetadata.schema.yaml
+  - $ref: Collection.schema.yaml
   - $ref: CreativeWork.schema.yaml
   - $ref: Datatable.schema.yaml
   - $ref: DatatableColumn.schema.yaml
@@ -13,11 +16,14 @@ anyOf:
   - $ref: Environment.schema.yaml
   - $ref: ErrorOutput.schema.yaml
   - $ref: ExecutionResultOutput.schema.yaml
+  - $ref: Expression.schema.yaml
   - $ref: ImageObject.schema.yaml
   - $ref: Include.schema.yaml
   - $ref: Mount.schema.yaml
   - $ref: name.schema.yaml
+  - $ref: Node.schema.yaml
   - $ref: Organization.schema.yaml
+  - $ref: Paragraph.schema.yaml
   - $ref: Person.schema.yaml
   - $ref: ResourceParameters.schema.yaml
   - $ref: Sheet.schema.yaml

--- a/schema/json-schema-draft-07.schema.json
+++ b/schema/json-schema-draft-07.schema.json
@@ -1,7 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://json-schema.org/draft-07/schema#",
-  "title": "Core schema meta-schema",
+  "$id": "http://json-schema.org/draft-07-copy/schema#",
+  "title": "JSONSchema",
+  "$comment": "This the JSON Schema draft-07 from the above URL. Only the $id and title has been modified to avoid clashes and for more consistent naming of generated Typescript type definitions and documentation pages. It is also useful to have this here for off-line validation / development.",
   "definitions": {
     "schemaArray": {
       "type": "array",

--- a/schema/software/Expression.schema.yaml
+++ b/schema/software/Expression.schema.yaml
@@ -7,3 +7,5 @@ allOf:
   - properties:
       type:
         enum: [Expression]
+required:
+  - type

--- a/schema/text/Blockquote.schema.yaml
+++ b/schema/text/Blockquote.schema.yaml
@@ -9,10 +9,9 @@ properties:
     enum: [Blockquote]
   content:
     '@id': 'stencila:content'
-    description: |
-      The content that is marked for deletion. Often indicated using a strike through style.
-    allOf:
-      - $ref: blockContent.schema.yaml
+    type: array
+    items:
+      $ref: blockContent.schema.yaml
 additionalProperties: false
 required:
   - type

--- a/schema/text/Heading.schema.yaml
+++ b/schema/text/Heading.schema.yaml
@@ -15,8 +15,9 @@ properties:
     maximum: 6
   content:
     description: Content of the heading.
-    allOf:
-      - $ref: inlineContent.schema.yaml
+    type: array
+    items:
+      $ref: inlineContent.schema.yaml
 required:
   - type
   - depth

--- a/schema/text/Paragraph.schema.yaml
+++ b/schema/text/Paragraph.schema.yaml
@@ -14,3 +14,4 @@ properties:
 additionalProperties: false
 required:
   - type
+  - content

--- a/schema/text/Table.schema.yaml
+++ b/schema/text/Table.schema.yaml
@@ -8,6 +8,7 @@ allOf:
   - $ref: CreativeWork.schema.yaml
   - properties:
       type:
+        type: string
         enum: [Table]
       rows:
         '@id': stencila:rows

--- a/schema/text/TableCell.schema.yaml
+++ b/schema/text/TableCell.schema.yaml
@@ -28,6 +28,7 @@ properties:
         minimum: 0
     minItems: 2
     maxItems: 2
+    tsType: '[number, number]'
   colspan:
     '@id': stencila:colspan
     description: |
@@ -56,4 +57,5 @@ properties:
 additionalProperties: false
 required:
   - type
+  - position
   - content

--- a/schema/text/inlineContent.schema.yaml
+++ b/schema/text/inlineContent.schema.yaml
@@ -2,6 +2,7 @@ $schema: http://json-schema.org/draft-07/schema#
 $id: https://stencila.github.com/schema/inlineContent.schema.json
 description: Inline content.
 anyOf:
+  - type: 'null'
   - type: boolean
   - type: integer
   - type: number
@@ -10,3 +11,4 @@ anyOf:
   - $ref: Strong.schema.yaml
   - $ref: Delete.schema.yaml
   - $ref: Verbatim.schema.yaml
+  - $ref: Expression.schema.yaml


### PR DESCRIPTION
This adds a number of types and properties as found necessary for conversion of `xlsx`, `csv` and `datapackage.json` files in the `stencila/convert` repo. Merging in now to get a release for use in that repo.