### PR TITLE
Generate schema.json files in "built" directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/built
 /coverage
 /dist
 /node_modules

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 .cache
+built
 coverage
 dist
 node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -3031,6 +3031,11 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
+    "author-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/author-regex/-/author-regex-1.0.0.tgz",
+      "integrity": "sha1-0IiFvmubv5Q5/gh8dihyRfCoFFA="
+    },
     "autoprefixer": {
       "version": "9.5.1",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.5.1.tgz",
@@ -19569,6 +19574,14 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "parse-author": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-author/-/parse-author-2.0.0.tgz",
+      "integrity": "sha1-00YL8d3Q367tQtp1QkLmX7aEqB8=",
+      "requires": {
+        "author-regex": "^1.0.0"
+      }
+    },
     "parse-bmfont-ascii": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/parse-bmfont-ascii/-/parse-bmfont-ascii-1.0.6.tgz",
@@ -19626,6 +19639,11 @@
         "map-cache": "^0.2.0",
         "path-root": "^0.1.1"
       }
+    },
+    "parse-full-name": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/parse-full-name/-/parse-full-name-1.2.3.tgz",
+      "integrity": "sha1-WimDAbmpCkLqthGCgV8+E6Ofq+0="
     },
     "parse-github-url": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "fs-extra": "^7.0.1",
     "globby": "^9.2.0",
     "immer": "^2.1.5",
+    "parse-author": "^2.0.0",
+    "parse-full-name": "^1.2.3",
     "prismjs": "^1.16.0",
     "rbx": "^2.1.0",
     "react": "^16.8.6",

--- a/schema/organization/Person.schema.yaml
+++ b/schema/organization/Person.schema.yaml
@@ -4,6 +4,7 @@ $extends: ../Thing.schema.yaml
 role: secondary
 status: unstable
 description: A person (alive, dead, undead, or fictional). https://schema.org/Person.
+parser: person
 properties:
   affiliations:
     '@id': schema:affiliation
@@ -29,13 +30,16 @@ properties:
   familyNames:
     '@id': schema:familyName
     aliases:
+      - familyName
       - surname
       - surnames
       - lastName
       - lastNames
-    type: array
-    items:
-      type: string
+    anyOf:
+      - parser: ssv
+      - type: array
+        items:
+          type: string
   funders:
     '@id': schema:funder
     type: array
@@ -45,12 +49,15 @@ properties:
         - $ref: Person.schema.yaml
   givenNames:
     '@id': schema:givenName
-    type: array
-    items:
-      type: string
     aliases:
+      - givenName
       - firstName
       - firstNames
+    anyOf:
+      - parser: ssv
+      - type: array
+        items:
+          type: string
   honorificPrefix:
     '@id': schema:honorificPrefix
     type: string

--- a/schema/organization/Person.ts
+++ b/schema/organization/Person.ts
@@ -1,0 +1,31 @@
+//@ts-ignore
+import parseAuthor from 'parse-author'
+//@ts-ignore
+import { parseFullName } from 'parse-full-name'
+import { Person } from '../../types'
+import { validate } from '../../util'
+
+export default Person
+
+/**
+ * Parse string data into a `Person`.
+ *
+ * @param data Data to parse
+ */
+export function parse(data: string): Person {
+  const { name, email, url } = parseAuthor(data)
+  const { title, first, middle, last, suffix } = parseFullName(name)
+  const person: Person = { type: 'Person' }
+  if (title) person.honorificPrefix = title
+  if (first) {
+    person.givenNames = [first]
+    if (middle) person.givenNames.push(middle)
+  }
+  if (last) person.familyNames = [last]
+  else throw new Error(`Unable to parse string "${data}" as a person`)
+  if (suffix) person.honorificSuffix = suffix
+  if (email) person.emails = [email]
+  if (url) person.url = url
+  validate(person, 'Person')
+  return person
+}

--- a/tests/Person.test.ts
+++ b/tests/Person.test.ts
@@ -1,11 +1,61 @@
-import { mutate } from '../util'
+import { create, validate, mutate } from '../util'
+import { parse } from '../schema/organization/Person'
+
+describe('validate', () => {
+  it('throws for invalid emails', () => {
+    expect(() =>
+      validate(
+        {
+          type: 'Person',
+          emails: ['pete@example.com', 'pete_at_example_com']
+        },
+        'Person'
+      )
+    ).toThrow('/emails/1: format should match format "email"')
+  })
+})
+
+describe('parse', () => {
+  it('works', () => {
+    let person = create('Person')
+
+    person.familyNames = ['Jones']
+    expect(parse('Jones')).toEqual(person)
+
+    person.givenNames = ['Jane', 'Jill']
+    expect(parse('Jane Jill Jones')).toEqual(person)
+
+    person.honorificPrefix = 'Dr'
+    expect(parse('Dr Jane Jill Jones')).toEqual(person)
+
+    person.honorificSuffix = 'PhD'
+    expect(parse('Dr Jane Jill Jones PhD')).toEqual(person)
+
+    person.emails = ['jane@example.com']
+    expect(parse('Dr Jane Jill Jones PhD <jane@example.com>')).toEqual(person)
+
+    person.url = 'http://example.com/jane'
+    expect(
+      parse(
+        'Dr Jane Jill Jones PhD <jane@example.com> (http://example.com/jane)'
+      )
+    ).toEqual(person)
+  })
+
+  it('throws', () => {
+    expect(() => parse('')).toThrow(/^Unable to parse string \"\" as a person$/)
+    expect(() => parse('#@&%')).toThrow(
+      /^Unable to parse string \"#@&%\" as a person$/s
+    )
+  })
+})
 
 describe('mutate', () => {
   it('coerces properties', () => {
     expect(
       mutate(
         {
-          givenNames: 'John',
+          givenNames: 'John Tom',
           familyNames: 'Smith',
           // Unfortunately it is not possible to
           // coerce an an object to an array of objects
@@ -20,7 +70,7 @@ describe('mutate', () => {
       )
     ).toEqual({
       type: 'Person',
-      givenNames: ['John'],
+      givenNames: ['John', 'Tom'],
       familyNames: ['Smith'],
       affiliations: [
         {
@@ -35,28 +85,75 @@ describe('mutate', () => {
     expect(
       mutate(
         {
-          firstName: 'John',
+          firstNames: 'John Tom',
           lastName: 'Smith'
         },
         'Person'
       )
     ).toEqual({
       type: 'Person',
-      givenNames: ['John'],
+      givenNames: ['John', 'Tom'],
       familyNames: ['Smith']
     })
+
     expect(
       mutate(
         {
-          givenName: 'John',
-          familyName: 'Smith'
+          givenName: 'Jane',
+          surnames: 'Doe Smith'
         },
         'Person'
       )
     ).toEqual({
       type: 'Person',
-      givenNames: ['John'],
-      familyNames: ['Smith']
+      givenNames: ['Jane'],
+      familyNames: ['Doe', 'Smith']
     })
+  })
+
+  it('parses strings into people', () => {
+    expect(
+      mutate(
+        {
+          authors: [
+            'John Smith',
+            'Dr Jane Jones PhD <jane@example.com>',
+            'Jones, Jack (http://example.com/jack)'
+          ]
+        },
+        'CreativeWork'
+      )
+    ).toEqual({
+      type: 'CreativeWork',
+      authors: [
+        {
+          type: 'Person',
+          givenNames: ['John'],
+          familyNames: ['Smith']
+        },
+        {
+          type: 'Person',
+          honorificPrefix: 'Dr',
+          givenNames: ['Jane'],
+          familyNames: ['Jones'],
+          honorificSuffix: 'PhD',
+          emails: ['jane@example.com']
+        },
+        {
+          type: 'Person',
+          givenNames: ['Jack'],
+          familyNames: ['Jones'],
+          url: 'http://example.com/jack'
+        }
+      ]
+    })
+  })
+
+  it('throws if string can not be parsed', () => {
+    expect(() =>
+      mutate({ authors: ['John Smith', '#@&%', 'Jones, Jane'] }, 'CreativeWork')
+    ).toThrow(
+      '/authors/1: parser error when parsing using "person": Unable to parse string "#@&%" as a person'
+    )
   })
 })

--- a/util.ts
+++ b/util.ts
@@ -90,7 +90,7 @@ export function cast<Key extends keyof stencila.Types>(
 
 // Load all schemas for use by Ajv
 const schemas = globby
-  .sync(path.join(__dirname, 'dist', '*.schema.json'))
+  .sync(path.join(__dirname, 'built', '*.schema.json'))
   .map(file => fs.readJSONSync(file))
 
 // Cached JSON Schema validation functions
@@ -154,7 +154,7 @@ const mutators = new Ajv({
 })
 
 // Read in aliases for use in mutate function
-const aliases = fs.readJSONSync(path.join(__dirname, 'dist', 'aliases.json'))
+const aliases = fs.readJSONSync(path.join(__dirname, 'built', 'aliases.json'))
 
 /**
  * Mutate a node so it conforms to a type's schema


### PR DESCRIPTION
This is necessary for distributing as a package.  The file `util.ts` needs to load the JSON Schema files at run time (we may take a different approach like bundling in the future but this applies nonetheless). So when distributed as a package the path for these can't be `path.join(__dirname, 'dist', ...)` as it currently is.
