### PR TITLE
fix: argument too long for prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "lint": "prettier --write **/**/*.{ts,tsx,js,jsx,json,css,md,mdx,yaml}",
+    "lint": "prettier --write '**/**/*.{ts,tsx,js,jsx,json,css,md,mdx,yaml}'",
     "test": "gulp test",
     "build": "npm run build:schema && npm run build:docs",
     "build:docs": "npm run build:schema && gatsby build --prefix-paths",


### PR DESCRIPTION
I have been having problems on my Mac with linting. 

```
> prettier --write **/**/*.{ts,tsx,js,jsx,json,css,md,mdx,yaml}

sh: /Users/aleksandra/Stencila/schema/node_modules/.bin/prettier: Argument list too long
npm ERR! code ELIFECYCLE
npm ERR! errno 126
npm ERR! @stencila/schema@0.7.0 lint: `prettier --write **/**/*.{ts,tsx,js,jsx,json,css,md,mdx,yaml}`
npm ERR! Exit status 126
npm ERR! 
npm ERR! Failed at the @stencila/schema@0.7.0 lint script.
```

This has been [reported by people using `zsh`](https://github.com/btholt/complete-intro-to-react/issues/91) I added their suggested fix and it works for me. I am not sure though if this has other implications but here's the PR