### PR TITLE
Update List & ListItem schemas

### DIFF
--- a/examples/list/nested.list.yaml
+++ b/examples/list/nested.list.yaml
@@ -1,12 +1,22 @@
 type: List
 items:
-  - Item One
+  - type: ListItem
+    content:
+      - Item One
   - type: ListItem
     content:
       - Item Two, containing nested children
       - type: List
-        content:
-          - Nested Item One
-          - Nested Item Two
-          - Nested Item Three
-  - Item Three
+        items:
+          - type: ListItem
+            content:
+              - Nested Item One
+          - type: ListItem
+            content:
+              - Nested Item Two
+          - type: ListItem
+            content:
+              - Nested Item Three
+  - type: ListItem
+    content:
+      - Item Three

--- a/examples/list/simple.list.yaml
+++ b/examples/list/simple.list.yaml
@@ -1,5 +1,11 @@
 type: List
 items:
-  - Item One
-  - Item Two
-  - Item Three
+  - type: ListItem
+    content:
+      - Item One
+  - type: ListItem
+    content:
+      - Item Two
+  - type: ListItem
+    content:
+      - Item Three

--- a/schema/text/List.md
+++ b/schema/text/List.md
@@ -17,7 +17,7 @@ If an `order` field is not defined, the list is assumed to be `unordered`.
 
 ### Nested Ordered List Inside an Unordered List
 
-A [`ListItem`](/schema/ListItem) can contain any valid [`BlockContent`](/schema/BlockContent), meaning that lists can be nested and/or contain other block elements.
+A [`ListItem`](/schema/ListItem) can contain any valid `Node`, meaning that lists can be nested and/or contain other block elements.
 
 ```json
 {

--- a/schema/text/List.schema.yaml
+++ b/schema/text/List.schema.yaml
@@ -11,7 +11,7 @@ properties:
     description: The items in the list
     type: array
     items:
-      $ref: Node.schema.yaml
+      $ref: ListItem.schema.yaml
   order:
     '@id': 'schema:itemListOrder'
     description: Type of ordering.

--- a/schema/text/ListItem.md
+++ b/schema/text/ListItem.md
@@ -15,7 +15,7 @@ The `ListItem` schema represents a collection of items, which can be ordered or 
 
 ### Nested Ordered List Inside an Unordered List
 
-A list item can contain any valid [`BlockContent`](/schema/BlockContent), meaning that lists can be nested and/or contain other block elements.
+A list item can contain any valid `Node`, meaning that lists can be nested and/or contain other block elements.
 
 ```json
 {
@@ -54,7 +54,7 @@ completable, omit the `checked` field.
 [`<list-item>`](https://jats.nlm.nih.gov/articleauthoring/tag-library/1.2/element/list-item.html)
 type.
 Note that JATS only permits the `ListItem` to contain either a
-[`Paragraph`](/schema/Paragraph) element, or another [`List`](/schema/List), while the Stencila equivalent is closer to HTML and accepts any valid [Block content](/schema/BlockContent).
+[`Paragraph`](/schema/Paragraph) element, or another [`List`](/schema/List), while the Stencila equivalent is closer to HTML and accepts any valid `Node`.
 
 ### mdast
 
@@ -65,6 +65,7 @@ Note that JATS only permits the `ListItem` to contain either a
 
 `ListItem` is analagous to the OpenDocument
 [`<text:list-item>`](http://docs.oasis-open.org/office/v1.2/os/OpenDocument-v1.2-os-part1.html#__RefHeading__1415154_253892949)
-element.
-Note that OpenDocument only permits the `ListItem` to contain either a
-[`Paragraph`](/schema/Paragraph) element, or another [`List`](/schema/List), while the Stencila equivalent is closer to HTML and accepts any valid [Block content](/schema/BlockContent).
+element. Note that OpenDocument only permits the `ListItem` to contain either
+a [`Paragraph`](/schema/Paragraph) element, or another
+[`List`](/schema/List), while the Stencila equivalent is closer to HTML and
+accepts any valid `Node`.

--- a/schema/text/ListItem.schema.yaml
+++ b/schema/text/ListItem.schema.yaml
@@ -9,7 +9,7 @@ properties:
     '@id': stencila:content
     type: array
     items:
-      $ref: BlockContent.schema.yaml
+      $ref: Node.schema.yaml
   checked:
     '@id': stencila:checked
     type: boolean


### PR DESCRIPTION
Changes `List` schema to require items to be of type `ListItems`, but then in turn opens up the `ListItem` schema to allow any `Node` type as children.