### PR TITLE
Add more schema documentation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -35,6 +35,7 @@
     "./built/ThematicBreak.schema.json": "*.thematicBreak.yaml",
     "./built/VideoObject.schema.json": "*videoObject.yaml",
     "./built/Quote.schema.json": "*quote.yaml",
+    "./built/QuoteBlock.schema.json": "*quoteBlock.yaml",
     "https://json-schema.org/draft-07/schema": "*.schema.yaml"
   },
   "cSpell.words": ["stencila"]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,6 +28,7 @@
     "./built/SoftwareApplication.schema.json": "*.softwareApplication.yaml",
     "./built/SoftwareSession.schema.json": "*.softwareSession.yaml",
     "./built/SoftwareSourceCode.json": "*.softwareSourceCode.yaml",
+    "./built/Strong.schema.json": "*.strong.yaml",
     "./built/Table.schema.json": "*.table.yaml",
     "./built/TableCell.schema.json": "*.tableCell.yaml",
     "./built/TableRow.schema.json": "*.tableRow.yaml",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,6 +13,7 @@
     "./built/Heading.schema.json": "*.heading.yaml",
     "./built/ImageObject.schema.json": "*.imageObject.yaml",
     "./built/Include.schema.json": "*.include.yaml",
+    "./built/Link.schema.json": "*.link.yaml",
     "./built/List.schema.json": "*.list.yaml",
     "./built/ListItem.schema.json": "*.listItem.yaml",
     "./built/MediaObject.schema.json": "*mediaObject.yaml",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,6 +34,7 @@
     "./built/TableRow.schema.json": "*.tableRow.yaml",
     "./built/ThematicBreak.schema.json": "*.thematicBreak.yaml",
     "./built/VideoObject.schema.json": "*videoObject.yaml",
+    "./built/Quote.schema.json": "*quote.yaml",
     "https://json-schema.org/draft-07/schema": "*.schema.yaml"
   },
   "cSpell.words": ["stencila"]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,11 @@
 {
   "yaml.schemas": {
-    "https://json-schema.org/draft-07/schema": "*.schema.yaml",
     "./built/Article.schema.json": "*.article.yaml",
     "./built/AudioObject.schema.json": "*audioObject.yaml",
     "./built/Brand.schema.json": "*.brand.yaml",
+    "./built/Collection.schema.json": "collection.*.yaml",
     "./built/ContactPoint.schema.json": "*.contactPoint.yaml",
     "./built/CreativeWork.schema.json": "*.creativeWork.yaml",
-    "./built/Collection.schema.json": "collection.*.yaml",
     "./built/Datatable.schema.json": "*.datatable.yaml",
     "./built/DatatableColumn.json": "*.datatableColumn.yaml",
     "./built/Document.schema.json": "*.document.yaml",
@@ -32,7 +31,9 @@
     "./built/Table.schema.json": "*.table.yaml",
     "./built/TableCell.schema.json": "*.tableCell.yaml",
     "./built/TableRow.schema.json": "*.tableRow.yaml",
-    "./built/VideoObject.schema.json": "*videoObject.yaml"
+    "./built/ThematicBreak.schema.json": "*.thematicBreak.yaml",
+    "./built/VideoObject.schema.json": "*videoObject.yaml",
+    "https://json-schema.org/draft-07/schema": "*.schema.yaml"
   },
   "cSpell.words": ["stencila"]
 }

--- a/examples/link/simple.link.yaml
+++ b/examples/link/simple.link.yaml
@@ -1,0 +1,4 @@
+type: Link
+content:
+  - Stencila’s website
+target: https://stenci.la

--- a/examples/link/withRelationship.link.yaml
+++ b/examples/link/withRelationship.link.yaml
@@ -1,0 +1,5 @@
+type: Link
+content:
+  - Stencila’s website
+target: https://stenci.la
+relation: external

--- a/examples/paragraph/nested.paragraph.yaml
+++ b/examples/paragraph/nested.paragraph.yaml
@@ -1,0 +1,10 @@
+type: Paragraph
+content:
+  - Some text with some
+  - type: Emphasis
+    content:
+      - emphasised words
+  - ' and '
+  - type: Strong
+    content:
+      - some strongly emphasised words

--- a/examples/paragraph/simple.paragraph.yaml
+++ b/examples/paragraph/simple.paragraph.yaml
@@ -1,10 +1,3 @@
 type: Paragraph
 content:
-  - Some text with some
-  - type: Emphasis
-    content:
-      - emphasised words
-  - ' and '
-  - type: Strong
-    content:
-      - some strongly emphasised words
+  - Some text content representing ideas expressed as words.

--- a/examples/quote/attributed.quote.yaml
+++ b/examples/quote/attributed.quote.yaml
@@ -1,0 +1,4 @@
+type: Quote
+content:
+  - 'If you wish to make an apple pie from scratch, you must first invent the universe. — Carl Sagan - Cosmos'
+citation: 'https://www.goodreads.com/quotes/32952-if-you-wish-to-make-an-apple-pie-from-scratch'

--- a/examples/quote/simple.quote.yaml
+++ b/examples/quote/simple.quote.yaml
@@ -1,0 +1,3 @@
+type: Quote
+content:
+  - 'If you wish to make an apple pie from scratch, you must first invent the universe. — Carl Sagan - Cosmos'

--- a/examples/quoteBlock/attributed.quoteBlock.yaml
+++ b/examples/quoteBlock/attributed.quoteBlock.yaml
@@ -1,0 +1,7 @@
+type: QuoteBlock
+content:
+  - type: Paragraph
+    content:
+      - 'If you wish to make an apple pie from scratch, you must first invent the universe.'
+      - 'by Carl Sagan — Cosmos'
+citation: 'https://www.goodreads.com/quotes/32952-if-you-wish-to-make-an-apple-pie-from-scratch'

--- a/examples/quoteBlock/simple.quoteBlock.yaml
+++ b/examples/quoteBlock/simple.quoteBlock.yaml
@@ -1,0 +1,6 @@
+type: QuoteBlock
+content:
+  - type: Paragraph
+    content:
+      - 'If you wish to make an apple pie from scratch, you must first invent the universe.'
+      - 'by Carl Sagan - Cosmos'

--- a/examples/strong/nested.strong.yaml
+++ b/examples/strong/nested.strong.yaml
@@ -1,0 +1,7 @@
+type: Strong
+content:
+  - 'Some '
+  - type: Delete
+    content:
+      - 'important'
+  - 'essential information'

--- a/examples/strong/simple.strong.yaml
+++ b/examples/strong/simple.strong.yaml
@@ -1,0 +1,3 @@
+type: Strong
+content:
+  - 'Some important information'

--- a/examples/thematicBreak/simple.thematicBreak.yaml
+++ b/examples/thematicBreak/simple.thematicBreak.yaml
@@ -1,0 +1,1 @@
+type: ThematicBreak

--- a/schema/Link.md
+++ b/schema/Link.md
@@ -1,0 +1,41 @@
+# Link
+
+The `Link` schema represents a hyperlink to other pages, sections within the same document, resources, or any URL.
+
+## Examples
+
+### Simple
+
+```json validate
+{
+  "type": "Link",
+  "content": ["Stencila’s website"],
+  "target": "https://stenci.la"
+}
+```
+
+## Related
+
+### HTML
+
+`Link` is analagous to the HTML [`<a>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) element.
+
+### JATS
+
+`Link` is analagous to the JATS [`<ext-link>`](https://jats.nlm.nih.gov/articleauthoring/tag-library/1.2/element/ext-link.html) element.
+
+### mdast
+
+`Link` is analagous to the mdast [`Link`](https://github.com/syntax-tree/mdast#link) node.
+
+### OpenDocument
+
+`Link` is analagous to the OpenDocument
+[`<text:a>`](http://docs.oasis-open.org/office/v1.2/os/OpenDocument-v1.2-os-part1.html#__RefHeading__1415212_253892949)
+element.
+
+### Pandoc
+
+`Link` is analagous to the Pandoc
+[`Link`](https://github.com/jgm/pandoc-types/blob/1.17.5.4/Text/Pandoc/Definition.hs#L270)
+type.

--- a/schema/Paragraph.md
+++ b/schema/Paragraph.md
@@ -1,0 +1,60 @@
+# Paragraph
+
+The `Paragraph` schema represents a paragraph, or a block of text. It can contain any valid [`InlineContent`](/schema/InlineContent) nodes.
+
+## Examples
+
+### Simple
+
+```json validate
+{
+  "type": "Paragraph",
+  "content": ["Some text content representing ideas expressed as words."]
+}
+```
+
+### Nested Content
+
+```json validate
+{
+  "type": "Paragraph",
+  "content": [
+    "Some text with some",
+    {
+      "type": "Emphasis",
+      "content": ["emphasised words"]
+    },
+    " and ",
+    {
+      "type": "Strong",
+      "content": ["some strongly emphasised words"]
+    }
+  ]
+}
+```
+
+## Related
+
+### HTML
+
+`Paragraph` is analagous to the HTML [`<p>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p) element.
+
+### JATS
+
+`Paragraph` is analagous to the JATS [`<p>`](https://jats.nlm.nih.gov/articleauthoring/tag-library/1.2/element/p.html) element.
+
+### mdast
+
+`Paragraph` is analagous to the mdast [`Paragraph`](https://github.com/syntax-tree/mdast#Paragraph) node.
+
+### OpenDocument
+
+`Paragraph` is analagous to the OpenDocument
+[`<text:p>`](http://docs.oasis-open.org/office/v1.2/os/OpenDocument-v1.2-os-part1.html#__RefHeading__1415138_253892949)
+element.
+
+### Pandoc
+
+`Paragraph` is analagous to the Pandoc
+[`Para`](https://github.com/jgm/pandoc-types/blob/1.17.5.4/Text/Pandoc/Definition.hs#L220)
+type.

--- a/schema/Quote.md
+++ b/schema/Quote.md
@@ -1,0 +1,52 @@
+# Quote
+
+The `Quote` schema represents inline quoted content.
+
+## Examples
+
+### Simple
+
+```json validate
+{
+  "type": "Quote",
+  "content": [
+    "If you wish to make an apple pie from scratch, you must first invent the universe. — Carl Sagan - Cosmos"
+  ]
+}
+```
+
+### With Attribution URI
+
+```json validate
+{
+  "type": "Quote",
+  "content": [
+    "If you wish to make an apple pie from scratch, you must first invent the universe. — Carl Sagan - Cosmos"
+  ],
+  "citation": "https://www.goodreads.com/quotes/32952-if-you-wish-to-make-an-apple-pie-from-scratch"
+}
+```
+
+## Related
+
+### HTML
+
+`Quote` is analagous to the HTML [`<q>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/q).
+
+### JATS
+
+`Quote` is analogous to the JATS
+[`<disp-quote>`](https://jats.nlm.nih.gov/articleauthoring/tag-library/1.2/element/disp-quote.html)
+type, and the [`<attrib>` element](https://jats.nlm.nih.gov/articleauthoring/tag-library/1.2/element/attrib.html) can be used for the `citation` field from the Stencila schema.
+
+### mdast
+
+`Quote` does not have mdast counterpart type, however please see the [`QuoteBlock`](/schema/QuoteBlock) schema for how to represent quotes in mdast.
+
+### OpenDocument
+
+`Quote` does not have an analogous OpenDocument element.
+
+### Pandoc
+
+`Quote` is analagous to the Pandoc [`Quoted` type](https://github.com/jgm/pandoc-types/blob/1.17.5.4/Text/Pandoc/Definition.hs#L262).

--- a/schema/Quote.md~Stashed changes
+++ b/schema/Quote.md~Stashed changes
@@ -1,0 +1,52 @@
+# Quote
+
+The `Quote` schema represents inline quoted content.
+
+## Examples
+
+### Simple
+
+```json validate
+{
+  "type": "Quote",
+  "content": [
+    "If you wish to make an apple pie from scratch, you must first invent the universe. — Carl Sagan - Cosmos"
+  ]
+}
+```
+
+### With Attribution URI
+
+```json validate
+{
+  "type": "Quote",
+  "content": [
+    "If you wish to make an apple pie from scratch, you must first invent the universe. — Carl Sagan - Cosmos"
+  ],
+  "citation": "https://www.goodreads.com/quotes/32952-if-you-wish-to-make-an-apple-pie-from-scratch"
+}
+```
+
+## Related
+
+### HTML
+
+`Quote` is analagous to the HTML [`<q>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/q).
+
+### JATS
+
+`Quote` is analogous to the JATS
+[`<disp-quote>`](https://jats.nlm.nih.gov/articleauthoring/tag-library/1.2/element/disp-quote.html)
+type, and the [`<attrib>` element](https://jats.nlm.nih.gov/articleauthoring/tag-library/1.2/element/attrib.html) can be used for the `citation` field from the Stencila schema.
+
+### mdast
+
+`Quote` does not have mdast counterpart type, however please see the [`QuoteBlock`](/schema/QuoteBlock) schema for how to represent quotes in mdast.
+
+### OpenDocument
+
+`Quote` does not have an analogous OpenDocument element.
+
+### Pandoc
+
+`Quote` is analagous to the Pandoc [`Quoted` type](https://github.com/jgm/pandoc-types/blob/1.17.5.4/Text/Pandoc/Definition.hs#L262).

--- a/schema/QuoteBlock.md
+++ b/schema/QuoteBlock.md
@@ -1,0 +1,66 @@
+# Quote Block
+
+The `QuoteBlock` schema represents an extended quoted sections.
+
+## Examples
+
+### Simple
+
+```json validate
+{
+  "type": "QuoteBlock",
+  "content": [
+    {
+      "type": "Paragraph",
+      "content": [
+        "If you wish to make an apple pie from scratch, you must first invent the universe.",
+        "by Carl Sagan - Cosmos"
+      ]
+    }
+  ]
+}
+```
+
+### With Attribution URI
+
+```json validate
+{
+  "type": "QuoteBlock",
+  "content": [
+    {
+      "type": "Paragraph",
+      "content": [
+        "If you wish to make an apple pie from scratch, you must first invent the universe.",
+        "by Carl Sagan — Cosmos"
+      ]
+    }
+  ],
+  "citation": "https://www.goodreads.com/quotes/32952-if-you-wish-to-make-an-apple-pie-from-scratch"
+}
+```
+
+## Related
+
+### HTML
+
+`QuoteBlock` is analagous to the HTML [`<blockquote>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/blockquote) element.
+
+### JATS
+
+`Quote` is analogous to the JATS
+[`<disp-quote>`](https://jats.nlm.nih.gov/articleauthoring/tag-library/1.2/element/disp-quote.html)
+type, and the [`<attrib>` element](https://jats.nlm.nih.gov/articleauthoring/tag-library/1.2/element/attrib.html) can be used for the `citation` field from the Stencila schema.
+
+### mdast
+
+`QuoteBlock` is analagous to the mdast [`Blockquote`](https://github.com/syntax-tree/mdast#blockquote) node type.
+
+### OpenDocument
+
+`QuoteBlock` does not have an analogous OpenDocument element.
+
+### Pandoc
+
+`QuoteBlock` is analagous to the Pandoc
+[`BlockQuote`](https://github.com/jgm/pandoc-types/blob/1.17.5.4/Text/Pandoc/Definition.hs#L224)
+type.

--- a/schema/Strong.md
+++ b/schema/Strong.md
@@ -1,0 +1,43 @@
+# Strong
+
+The `Strong` schema represents strongly emphasised content. It can contain any valid [`InlineContent`](/schema/InlineContent) nodes.
+
+## Examples
+
+### Simple
+
+```json validate
+{
+  "type": "Strong",
+  "content": ["Some important information"]
+}
+```
+
+### Nested types
+
+```json validate
+{
+  "type": "Strong",
+  "content": [
+    "Some ",
+    { "type": "Delete", "content": ["important"] },
+    "essential information"
+  ]
+}
+```
+
+## Related
+
+### JATS
+
+`Strong` is analagous, and structurally similar to, the JATS [`<bold>`](https://jats.nlm.nih.gov/articleauthoring/tag-library/1.2/element/aut-elem-sec-intro.html) type.
+
+### mdast
+
+`Strong` is analagous to the mdast [`Strong`](https://github.com/syntax-tree/mdast#strong) node type.
+
+### OpenDocument
+
+`Strong` is similar to the OpenDocument
+[`<style:font-adornments>`](http://docs.oasis-open.org/office/v1.2/os/OpenDocument-v1.2-os-part1.html#__RefHeading__1417910_253892949)
+attribute.

--- a/schema/ThematicBreak.md
+++ b/schema/ThematicBreak.md
@@ -1,0 +1,34 @@
+# Thematic Break
+
+The `ThematicBreak` schema represents a thematic break, such as a scene change in a story, a transition to another topic, or a new document.
+
+The way a thematic break is represented can vary from one format to another,
+in markdown and HTML for example it is often represented as a horizontal rule
+but in text editors can be represented as either a horizontal rule or a page
+break.
+
+## Examples
+
+### Simple
+
+```json validate
+{
+  "type": "ThematicBreak"
+}
+```
+
+## Related
+
+### JATS
+
+`ThematicBreak` does not have a similar counterpart in JATS. The [`<hr>`](https://jats.nlm.nih.gov/articleauthoring/tag-library/1.2/element/hr.html) type is defined as an explicit horizontal rule and only recommended to be used in a table, whereas the Stencila `ThematicBreak` type can be used in broader contexts.
+
+### mdast
+
+`ThematicBreak` is analagous to the mdast [``](https://github.com/syntax-tree/mdast#ThematicBreak) node type.
+
+### OpenDocument
+
+`ThematicBreak` is similar to the OpenDocument
+[`<text:soft-page-break>`](http://docs.oasis-open.org/office/v1.2/os/OpenDocument-v1.2-os-part1.html#element-text_soft-page-break)
+element.


### PR DESCRIPTION
Part of the schema documentation initiative (#82)

Adds schemas for:
-  Link
-  Paragraph
-  Quote
-  QuoteBlock
-  Strong
-  ThematicBreak

The commits are atomic per schema, so might be easier to review them as such.