### PR TITLE
96 add entity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5496,7 +5496,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5517,12 +5518,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5537,17 +5540,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5664,7 +5670,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5676,6 +5683,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5690,6 +5698,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5697,12 +5706,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5721,6 +5732,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5801,7 +5813,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5813,6 +5826,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5898,7 +5912,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5934,6 +5949,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5953,6 +5969,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5996,12 +6013,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/schema/DatatableColumnSchema.schema.yaml
+++ b/schema/DatatableColumnSchema.schema.yaml
@@ -1,6 +1,6 @@
 title: DatatableColumnSchema
 '@id': stencila:DatatableColumnSchema
-$extends: Thing.schema.yaml
+$extends: Entity.schema.yaml
 role: tertiary
 status: experimental
 properties:

--- a/schema/Entity.schema.yaml
+++ b/schema/Entity.schema.yaml
@@ -1,0 +1,23 @@
+title: Entity
+'@id': stencila:Entity
+role: base
+status: unstable
+description: The most basic item, defining the minimum properties required.
+type: object
+properties:
+  type:
+    # This is a special property analagous to JSON-LD's `@type` keyword
+    # and so should not have a `@id` since it is not a property.
+    # It is extended with the titles of all descendant types during
+    # the generation of schema.json files.
+    description: The name of the type and all descendant types.
+    type: string
+    enum: [Entity]
+    default: Entity
+  id:
+    # This is a special property analagous to JSON-LD's `@id` keyword
+    # and so should not have a `@id` since it is not a property.
+    description: The identifier for this item.
+    type: string
+required:
+  - type

--- a/schema/Heading.schema.yaml
+++ b/schema/Heading.schema.yaml
@@ -1,6 +1,6 @@
 title: Heading
 '@id': stencila:Heading
-$extends: Thing.schema.yaml
+$extends: Entity.schema.yaml
 role: secondary
 status: experimental
 description: Heading

--- a/schema/Include.schema.yaml
+++ b/schema/Include.schema.yaml
@@ -4,7 +4,7 @@ description: |
   A directive to include content from an external source (e.g. file, URL) or content.
 role: secondary
 status: experimental
-$extends: Thing.schema.yaml
+$extends: Entity.schema.yaml
 properties:
   source:
     description: The JSON Reference to the included content.

--- a/schema/Link.schema.yaml
+++ b/schema/Link.schema.yaml
@@ -1,6 +1,6 @@
 title: Link
 '@id': stencila:Link
-$extends: Thing.schema.yaml
+$extends: Entity.schema.yaml
 role: secondary
 status: unstable
 description: A hyperlink to other pages, sections within the same document, resources, or any URL.

--- a/schema/List.schema.yaml
+++ b/schema/List.schema.yaml
@@ -1,6 +1,6 @@
 title: List
 '@id': schema:ItemList
-$extends: Thing.schema.yaml
+$extends: Entity.schema.yaml
 role: secondary
 status: unstable
 description: |

--- a/schema/ListItem.schema.yaml
+++ b/schema/ListItem.schema.yaml
@@ -1,6 +1,6 @@
 title: ListItem
 '@id': schema:ListItem
-$extends: Thing.schema.yaml
+$extends: Entity.schema.yaml
 role: tertiary
 status: stable
 description: A single item in a list.

--- a/schema/Mark.schema.yaml
+++ b/schema/Mark.schema.yaml
@@ -1,6 +1,6 @@
 title: Mark
 '@id': stencila:Mark
-$extends: Thing.schema.yaml
+$extends: Entity.schema.yaml
 role: base
 status: stable
 description: |

--- a/schema/Paragraph.schema.yaml
+++ b/schema/Paragraph.schema.yaml
@@ -1,6 +1,6 @@
 title: Paragraph
 '@id': stencila:Paragraph
-$extends: Thing.schema.yaml
+$extends: Entity.schema.yaml
 role: secondary
 status: experimental
 description: Paragraph

--- a/schema/QuoteBlock.schema.yaml
+++ b/schema/QuoteBlock.schema.yaml
@@ -1,6 +1,6 @@
 title: QuoteBlock
 '@id': stencila:QuoteBlock
-$extends: Thing.schema.yaml
+$extends: Entity.schema.yaml
 role: secondary
 status: stable
 description: |

--- a/schema/TableCell.schema.yaml
+++ b/schema/TableCell.schema.yaml
@@ -1,6 +1,6 @@
 title: TableCell
 '@id': stencila:TableCell
-$extends: Thing.schema.yaml
+$extends: Entity.schema.yaml
 role: secondary
 status: experimental
 description: |

--- a/schema/TableRow.schema.yaml
+++ b/schema/TableRow.schema.yaml
@@ -1,6 +1,6 @@
 title: TableRow
 '@id': stencila:TableRow
-$extends: Thing.schema.yaml
+$extends: Entity.schema.yaml
 role: secondary
 status: experimental
 description: A row within a Table.

--- a/schema/ThematicBreak.schema.yaml
+++ b/schema/ThematicBreak.schema.yaml
@@ -1,6 +1,6 @@
 title: ThematicBreak
 '@id': stencila:ThematicBreak
-$extends: Thing.schema.yaml
+$extends: Entity.schema.yaml
 role: secondary
 status: stable
 description: |

--- a/schema/Thing.schema.yaml
+++ b/schema/Thing.schema.yaml
@@ -1,24 +1,10 @@
 title: Thing
 '@id': schema:Thing
-role: base
+$extends: Entity.schema.yaml
 status: unstable
 description: The most generic type of item https://schema.org/Thing.
 type: object
 properties:
-  type:
-    # This is a special property analagous to JSON-LD's `@type` keyword
-    # and so should not have a `@id` since it is not a property.
-    # It is extended with the titles of all descendant types during
-    # the generation of schema.json files.
-    description: The name of the type and all descendant types.
-    type: string
-    enum: [Thing]
-    default: Thing
-  id:
-    # This is a special property analagous to JSON-LD's `@id` keyword
-    # and so should not have a `@id` since it is not a property.
-    description: The identifier for this item.
-    type: string
   alternateNames:
     '@id': schema:alternateName
     description: Alternate names (aliases) for the item.
@@ -46,5 +32,3 @@ properties:
     description: The URL of the item.
     type: string
     format: uri
-required:
-  - type


### PR DESCRIPTION
Added `Entity` class as the base instead of `Thing`. Refactored items that I thought were "presentation" to inherit from `Entity` instead of `Thing`. These are:

DatatableColumnSchema.schema.yaml
Heading.schema.yaml
Include.schema.yaml
Link.schema.yaml
List.schema.yaml
ListItem.schema.yaml
Mark.schema.yaml
Paragraph.schema.yaml
QuoteBlock.schema.yaml
TableCell.schema.yaml
TableRow.schema.yaml
ThematicBreak.schema.yaml

Open to 