### PR TITLE
feat(Table): Add properties to indicate header cells

### DIFF
--- a/examples/table/header.table.yaml
+++ b/examples/table/header.table.yaml
@@ -1,0 +1,64 @@
+# Recreates the headers and first two rows from
+# https://www.w3.org/WAI/tutorials/tables/two-headers/#table-with-header-cells-in-the-top-row-and-first-column
+type: Table
+rows:
+  - type: TableRow
+    kind: header
+    cells:
+      - type: TableCell
+        content:
+          - Monday
+      - type: TableCell
+        content:
+          - Tuesday
+      - type: TableCell
+        content:
+          - Wednesday
+      - type: TableCell
+        content:
+          - Thursday
+      - type: TableCell
+        content:
+          - Friday
+  - type: TableRow
+    cells:
+      - type: TableCell
+        kind: header
+        content:
+          - '09:00 - 11:00'
+      - type: TableCell
+        content:
+          - Closed
+      - type: TableCell
+        content:
+          - Open
+      - type: TableCell
+        content:
+          - Open
+      - type: TableCell
+        content:
+          - Closed
+      - type: TableCell
+        content:
+          - Closed
+  - type: TableRow
+    cells:
+      - type: TableCell
+        kind: header
+        content:
+          - '11:00 - 13:00'
+      - type: TableCell
+        content:
+          - Open
+      - type: TableCell
+        content:
+          - Open
+      - type: TableCell
+        content:
+          - Closed
+      - type: TableCell
+        content:
+          - Closed
+      - type: TableCell
+        content:
+          - Closed

--- a/examples/table/irregularHeader.table.yaml
+++ b/examples/table/irregularHeader.table.yaml
@@ -1,0 +1,73 @@
+# Recreates the table from
+# https://www.w3.org/WAI/tutorials/tables/irregular/#table-with-two-tier-headers
+type: Table
+rows:
+  - type: TableRow
+    cells:
+      - type: TableCell
+        rowspan: 2
+        content: []
+      - type: TableCell
+        kind: header
+        colspan: 2
+        content:
+          - Mars
+      - type: TableCell
+        kind: header
+        colspan: 2
+        content:
+          - Venus
+  - type: TableRow
+    cells:
+      - type: TableCell
+        content:
+          - Produced
+      - type: TableCell
+        kind: header
+        content:
+          - Sold
+  - type: TableRow
+    cells:
+      - type: TableCell
+        content:
+          - Produced
+      - type: TableCell
+        kind: header
+        content:
+          - Sold
+  - type: TableRow
+    cells:
+      - type: TableCell
+        kind: header
+        content:
+          - Teddy Bears
+      - type: TableCell
+        content:
+          - 50,000
+      - type: TableCell
+        content:
+          - 30,000
+      - type: TableCell
+        content:
+          - 100,000
+      - type: TableCell
+        content:
+          - 80,000
+  - type: TableRow
+    cells:
+      - type: TableCell
+        kind: header
+        content:
+          - Board Games
+      - type: TableCell
+        content:
+          - 10,000
+      - type: TableCell
+        content:
+          - 5,000
+      - type: TableCell
+        content:
+          - 12,000
+      - type: TableCell
+        content:
+          - 9,000

--- a/schema/TableCell.schema.yaml
+++ b/schema/TableCell.schema.yaml
@@ -22,6 +22,16 @@ properties:
     minimum: 0
     maximum: 1000
     default: 1
+  kind:
+    '@id': stencila:TableCellKind
+    description: |
+      Indicates whether the cell is a header (similar to the HTML [`<th>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th)),
+      or a default data cell (similar to the HTML [`<td>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td)).
+    type: string
+    enum:
+      - data
+      - header
+    default: data
   rowspan:
     '@id': stencila:rowspan
     description: |

--- a/schema/TableCell.schema.yaml
+++ b/schema/TableCell.schema.yaml
@@ -23,7 +23,7 @@ properties:
     maximum: 1000
     default: 1
   kind:
-    '@id': stencila:TableCellKind
+    '@id': stencila:tableCellKind
     description: |
       Indicates whether the cell is a header (similar to the HTML [`<th>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th)),
       or a default data cell (similar to the HTML [`<td>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td)).

--- a/schema/TableRow.schema.yaml
+++ b/schema/TableRow.schema.yaml
@@ -11,5 +11,13 @@ properties:
     type: array
     items:
       $ref: TableCell
+  kind:
+    '@id': stencila:TableRowKind
+    description: |
+      If present, indicates that all cells in this row should be treated as header cells.
+    type: string
+    enum:
+      - header
+      - footer
 required:
   - cells

--- a/schema/TableRow.schema.yaml
+++ b/schema/TableRow.schema.yaml
@@ -12,7 +12,7 @@ properties:
     items:
       $ref: TableCell
   kind:
-    '@id': stencila:TableRowKind
+    '@id': stencila:tableRowKind
     description: |
       If present, indicates that all cells in this row should be treated as header cells.
     type: string


### PR DESCRIPTION
Closes #91 

Would appreciate feedback

Some notes, using HTML tags for demonstration:
- The idea is that if `kind: header/footer` is set on `TableRow` then the children could be wrapped in a `<thead>/<tfoot>` element, and the `kind: header` would be the default value when iterating over the children cells.
- For `TableCell` schema, the `kind` property can be either a `header` or `data`. The `data` variant is the default value and can be used to override the implicit `header` value passed from the the parent `TableRow` schema.

Couple of points for consideration:
- This does not implement something like the [HTML `scope` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th#attr-scope). I can see semantic benefits from using it, but can see it translating to only JATS and HTML.
- Not sure if there is a way to make a dependent schema properties, or even if we should try to. In this case, it's possibly to make a `TableRow` as being `kind: header`, this implicitly sets the `kind: header` property on all child cells, but no way to warn enforce the `kind: header` property on the child cells. It seems it would only fall to the implementation to provide any guarantees.
A possible solution would be to create a `TableHeaderRow` schema and a `TableHeaderCell` schema, but don't think the overhead quite justifies the complexity.
- Could you please provide guidance regarding the `@id` naming convention and how unique they are supposed to be please?

Thanks!