### PR TITLE
Add checking of the schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "@stencila/dev-config": "^1.1.3",
     "@stencila/encoda": "^0.60.4",
+    "@stencila/logga": "^1.2.1",
     "@types/fs-extra": "^8.0.0",
     "@types/jest": "^24.0.15",
     "@types/js-yaml": "^3.12.1",

--- a/schema/Article.schema.yaml
+++ b/schema/Article.schema.yaml
@@ -3,6 +3,7 @@ title: Article
 extends: CreativeWork
 role: primary
 status: unstable
+description: An article, including news and scholarly articles.
 properties:
   environment:
     '@id': stencila:environment

--- a/schema/AudioObject.schema.yaml
+++ b/schema/AudioObject.schema.yaml
@@ -3,16 +3,13 @@ title: AudioObject
 extends: MediaObject
 role: secondary
 status: stable
-description: |
-  An audio file. https://schema.org/AudioObject
+description: An audio file
 properties:
   caption:
     '@id': schema:caption
-    description: |
-      The caption for this audio recording.
+    description: The caption for this audio recording.
     type: string
   transcript:
     '@id': schema:transcript
-    description: |
-      The transcript of this audio recording.
+    description: The transcript of this audio recording.
     type: string

--- a/schema/Brand.schema.yaml
+++ b/schema/Brand.schema.yaml
@@ -4,20 +4,21 @@ extends: Thing
 role: tertiary
 status: unstable
 description: |
-  A brand is a name used by an organization or business person for labeling a product,
-  product group, or similar. https://schema.org/Brand.
+  A brand used by an organization or person for labeling a product,
+  product group, or similar.
 properties:
   logo:
-    description: |
-      A logo of of the brand. It can be either a URL of the image or image itself.
+    '@id': schema:logo
+    description: A logo associated with the brand.
     anyOf:
       - type: string
         format: uri
       - $ref: ImageObject
   reviews:
     '@id': schema:review
-    description: |
-      Short reviews of the brand and/or the products it represents.
+    description: Reviews of the brand.
     type: array
     items:
       type: string
+required:
+  - name

--- a/schema/CodeChunk.schema.yaml
+++ b/schema/CodeChunk.schema.yaml
@@ -3,13 +3,11 @@ title: CodeChunk
 extends: SoftwareSourceCode
 role: secondary
 status: unstable
-description: |
-  A executable chunk of code.
+description: A executable chunk of code.
 properties:
   outputs:
     '@id': stencila:outputs
-    description: |
-      Outputs from executing the chunk.
+    description: Outputs from executing the chunk.
     type: array
     items:
       $ref: Node

--- a/schema/CodeExpr.schema.yaml
+++ b/schema/CodeExpr.schema.yaml
@@ -3,9 +3,10 @@ title: CodeExpr
 extends: SoftwareSourceCode
 role: secondary
 status: unstable
-description: An expression.
+description: An expression defined in programming language source code.
 properties:
   value:
     '@id': schema:value
+    description: The value of the expression when it was last evaluated.
     allOf:
       - $ref: Node

--- a/schema/Collection.schema.yaml
+++ b/schema/Collection.schema.yaml
@@ -3,8 +3,7 @@ title: Collection
 extends: CreativeWork
 role: secondary
 status: stable
-description: |
-  A created collection of CreativeWorks or other artefacts.
+description: A created collection of CreativeWorks or other artefacts.
 # The [schema.org defintion](https://schema.org/Collection) adds
 # `collectionSize` but has not been added here because that feels
 # redudant e.g. a developer could use `collection.parts.length` instead

--- a/schema/ContactPoint.schema.yaml
+++ b/schema/ContactPoint.schema.yaml
@@ -3,26 +3,25 @@ title: ContactPoint
 extends: Thing
 role: tertiary
 status: unstable
-description: A contact point—for example, a R&D department. https://schema.org/ContactPoint.
+description: A contact point—for example, a R&D department.
 properties:
   availableLanguages:
     '@id': schema:availableLanguage
     description: |
-      Languages (human not programming) in which it is possible to communicate with the organization/department etc.
+      Languages (human not programming) in which it is possible to communicate
+      with the organization/department etc.
     type: array
     items:
       type: string
   emails:
     '@id': schema:email
-    description: |
-      Email address for correspondence. It must be provided in a valid email format (eg. info@example.com ).
+    description: Email address for correspondence.
     type: array
     items:
       type: string
       format: email
   telephone:
     '@id': schema:telephone
-    description: |
-      "Phone contact number. Accepted formats: +44 123455, (02)12345, 006645667."
+    description: "The telephone number of the contact point. Accepted formats: +44 123455, (02)12345, 006645667."
     type: string
     pattern: '^[+#*\(\)\[\]]*([0-9][ ext+-pw#*\(\)\[\]]*){6,45}$'

--- a/schema/CreativeWork.schema.yaml
+++ b/schema/CreativeWork.schema.yaml
@@ -4,12 +4,11 @@ extends: Thing
 role: base
 status: stable
 description: |
-  The most generic kind of creative work, including books, movies, photographs,
-  software programs, etc. https://schema.org/CreativeWork
+  A creative work, including books, movies, photographs, software programs, etc.
 properties:
   authors:
     '@id': schema:author
-    description: The authors of this this creative work.
+    description: The authors of this creative work.
     type: array
     items:
       anyOf:
@@ -123,11 +122,13 @@ properties:
     # The name "title" is more appropriate to our context than schema.org's "headline".
     # We provide the latter as an alias.
     '@id': schema:headline
+    description: The title of the creative work.
     aliases:
       - headline
     type: string
   version:
     '@id': schema:version
+    description: The version of the creative work.
     anyOf:
       - type: string
       - type: number

--- a/schema/Datatable.schema.yaml
+++ b/schema/Datatable.schema.yaml
@@ -6,7 +6,8 @@ status: experimental
 description: A table of data.
 properties:
   columns:
-    description: TODO
+    '@id': stencila:columns
+    description: The columns of data.
     type: array
     items:
       $ref: DatatableColumn

--- a/schema/DatatableColumn.schema.yaml
+++ b/schema/DatatableColumn.schema.yaml
@@ -3,13 +3,16 @@ title: DatatableColumn
 extends: Thing
 role: secondary
 status: experimental
+description: A column of data within a Datatable.
 properties:
   schema:
+    '@id': stencila:schema
     description: The schema to use to validate data in the column.
     allOf:
       - $ref: DatatableColumnSchema
   values:
-    description: The values of the column.
+    '@id': stencila:values
+    description: The data values of the column.
     type: array
 required:
   - name

--- a/schema/DatatableColumnSchema.schema.yaml
+++ b/schema/DatatableColumnSchema.schema.yaml
@@ -2,12 +2,17 @@ title: DatatableColumnSchema
 '@id': stencila:DatatableColumnSchema
 extends: Entity
 role: tertiary
-status: experimental
+status: unstable
+description: |
+  A schema specifying the data values that are valid within a Datatable column.
 properties:
   items:
+    '@id': stencila:items
+    description: An object representing the JSON Schema `items` keyword.
     type: object
   uniqueItems:
+    '@id': stencila:uniqueItems
+    description: A flag to indicate that each value in the column should be unique.
     type: boolean
-    default: false
 required:
   - items

--- a/schema/Entity.schema.yaml
+++ b/schema/Entity.schema.yaml
@@ -9,6 +9,7 @@ properties:
     # and so should not have a `@id` since it is not a property.
     # It is extended with the titles of all descendant types during
     # the generation of schema.json files.
+    '@id': schema:type
     description: The name of the type and all descendant types.
     type: string
     enum: [Entity]
@@ -16,6 +17,7 @@ properties:
   id:
     # This is a special property analogous to JSON-LD's `@id` keyword
     # and so should not have a `@id` since it is not a property.
+    '@id': schema:id
     description: The identifier for this item.
     type: string
   meta:

--- a/schema/Environment.schema.yaml
+++ b/schema/Environment.schema.yaml
@@ -23,11 +23,11 @@ properties:
     type: array
     items:
       $ref: SoftwareSourceCode
-  environmentSource:
+  source:
     '@id': stencila:environmentSource
     description: |
-      Source of environment definition. For example, a URL to a Dockerfile, a path to Singularity recipe file,
-      or a path to a filesystem folder.,
+      Source of environment definition. e.g. a URL to a Dockerfile,
+      or a path to a filesystem folder.
     type: string
 required:
   - name

--- a/schema/Heading.schema.yaml
+++ b/schema/Heading.schema.yaml
@@ -6,10 +6,13 @@ status: experimental
 description: Heading
 properties:
   depth:
+    '@id': stencila:depth
+    description: The depth of the heading.
     type: number
     minimum: 1
     maximum: 6
   content:
+    '@id': stencila:content
     description: Content of the heading.
     type: array
     items:

--- a/schema/ImageObject.schema.yaml
+++ b/schema/ImageObject.schema.yaml
@@ -3,17 +3,14 @@ title: ImageObject
 extends: MediaObject
 role: secondary
 status: stable
-description: |
-  An image file. https://schema.org/ImageObject
+description: An image file.
 properties:
   caption:
     '@id': schema:caption
-    description: |
-      The caption for this image.
+    description: The caption for this image.
     type: string
   thumbnail:
     '@id': schema:thumbnail
-    description: |
-      Thumbnail image of this image.
+    description: Thumbnail image of this image.
     allOf:
       - $ref: ImageObject

--- a/schema/Include.schema.yaml
+++ b/schema/Include.schema.yaml
@@ -7,15 +7,19 @@ status: experimental
 extends: Entity
 properties:
   source:
+    '@id': stencila:source
     description: The source of the content.
     type: string
   mediaType:
+    '@id': stencila:mediaType
     description: The media type of the source content.
     type: string
   hash:
+    '@id': stencila:hash
     description: A SHA256 hash of the source content and media type the last time that the source was decoded.
     type: string
   content:
+    '@id': stencila:content
     description: The content to be included.
     type: array
     items:

--- a/schema/Link.schema.yaml
+++ b/schema/Link.schema.yaml
@@ -7,11 +7,13 @@ description: A hyperlink to other pages, sections within the same document, reso
 properties:
   content:
     '@id': stencila:content
+    description: The textual content of the link.
     type: array
     items:
       $ref: InlineContent
   target:
     '@id': stencila:target
+    description: The target of the link.
     type: string
     format: uri
   title:

--- a/schema/ListItem.schema.yaml
+++ b/schema/ListItem.schema.yaml
@@ -7,11 +7,13 @@ description: A single item in a list.
 properties:
   content:
     '@id': stencila:content
+    description: The content of the list item.
     type: array
     items:
       $ref: Node
   checked:
     '@id': stencila:checked
+    description: A flag to indicate if this list item is checked.
     type: boolean
     default: false
 required:

--- a/schema/Mark.schema.yaml
+++ b/schema/Mark.schema.yaml
@@ -4,12 +4,12 @@ extends: Entity
 role: base
 status: stable
 description: |
-  A base class for nodes that mark some other inline content (e.g. `string` or other `InlineContent` nodes) in some way (e.g. as being emphasised, or quoted).
+  A base class for nodes that mark some other inline content
+  in some way (e.g. as being emphasised, or quoted).
 properties:
   content:
     '@id': 'stencila:content'
-    description: |
-      The content that is marked.
+    description: The content that is marked.
     type: array
     items:
       $ref: InlineContent

--- a/schema/MediaObject.schema.yaml
+++ b/schema/MediaObject.schema.yaml
@@ -5,7 +5,7 @@ role: base
 status: stable
 description: |
   A media object, such as an image, video, or audio object embedded in a web page or a
-  downloadable dataset. https://schema.org/MediaObject
+  downloadable dataset.
 properties:
   bitrate:
     '@id': schema:bitrate

--- a/schema/Organization.schema.yaml
+++ b/schema/Organization.schema.yaml
@@ -3,7 +3,7 @@ title: Organization
 extends: Thing
 role: secondary
 status: unstable
-description: An organization such as a school, NGO, corporation, club, etc. https://schema.org/Organization.
+description: An organization such as a school, NGO, corporation, club, etc.
 properties:
   address:
     '@id': schema:address

--- a/schema/Paragraph.schema.yaml
+++ b/schema/Paragraph.schema.yaml
@@ -6,6 +6,8 @@ status: experimental
 description: Paragraph
 properties:
   content:
+    '@id': 'stencila:content'
+    description: The contents of the paragraph.
     type: array
     items:
       $ref: InlineContent

--- a/schema/Person.schema.yaml
+++ b/schema/Person.schema.yaml
@@ -3,7 +3,7 @@ title: Person
 extends: Thing
 role: secondary
 status: stable
-description: A person (alive, dead, undead, or fictional). https://schema.org/Person.
+description: A person (alive, dead, undead, or fictional).
 codec: person
 properties:
   address:
@@ -31,9 +31,8 @@ properties:
       - surnames
       - lastName
       - lastNames
-    description: |
-      Family name. In the U.S., the last name of an Person.
-      This can be used along with givenName instead of the name property.
+    description: Family name. In the U.S., the last name of a person.
+    $comment: This can be used along with givenName instead of the name property.
     allOf:
       - codec: ssv
       - type: array
@@ -56,9 +55,8 @@ properties:
       - firstNames
       # It is necessary to specify this alias because of use of allOf
       - givenName
-    description: |
-      Given name. In the U.S., the first name of a Person.
-      This can be used along with familyName instead of the name property.
+    description: Given name. In the U.S., the first name of a person.
+    $comment: This can be used along with familyName instead of the name property.
     allOf:
       - codec: ssv
       - type: array

--- a/schema/Product.schema.yaml
+++ b/schema/Product.schema.yaml
@@ -4,22 +4,22 @@ extends: Thing
 role: tertiary
 status: stable
 description: |
-  Any offered product or service. For example, a pair of shoes; a concert ticket; the rental of a car;
-  a haircut; or an episode of a TV show streamed online. https://schema.org/Product
+  Any offered product or service. For example, a pair of shoes;
+  a haircut; or an episode of a TV show streamed online.
 properties:
   brand:
-    description: |
-      Brand that the product is labelled with.
-    $ref: Brand
+    '@id': schema:brand
+    description: Brand that the product is labelled with.
+    allOf:
+      - $ref: Brand
   logo:
-    description: |
-      A logo of of the product. It can be either a URL of the image or image itself.
+    '@id': schema:logo
+    description: The logo of the product.
     anyOf:
       - type: string
         format: uri
       - $ref: ImageObject
   productID:
     '@id': schema:productID
-    description: |
-      Product identification code.
+    description: Product identification code.
     type: string

--- a/schema/Quote.schema.yaml
+++ b/schema/Quote.schema.yaml
@@ -3,10 +3,7 @@ title: Quote
 extends: Mark
 role: secondary
 status: stable
-description: |
-  Inline, quoted content. Analagous to,
-    - HTML [`<q>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/q)
-    - Pandoc [`Quoted`](https://github.com/jgm/pandoc-types/blob/1.17.5.4/Text/Pandoc/Definition.hs#L262)
+description: Inline, quoted content.
 properties:
   citation:
     '@id': schema:citation

--- a/schema/QuoteBlock.schema.yaml
+++ b/schema/QuoteBlock.schema.yaml
@@ -13,6 +13,7 @@ properties:
     format: uri
   content:
     '@id': 'stencila:content'
+    description: The content of the quote.
     type: array
     items:
       $ref: BlockContent

--- a/schema/SoftwareApplication.schema.yaml
+++ b/schema/SoftwareApplication.schema.yaml
@@ -9,11 +9,12 @@ properties:
   softwareRequirements:
     '@id': schema:softwareRequirements
     description: |
-      Component dependency requirements for application. This includes runtime environments and shared libraries that are not included in the application distribution package, but required to run the application (Examples: DirectX, Java or .NET runtime).
+      Requirements for application, including shared libraries that
+      are not included in the application distribution.
     type: array
     items:
       - $ref: SoftwareApplication
   softwareVersion:
     '@id': schema:softwareVersion
-    description: Version of the software instance.
+    description: Version of the software.
     type: string

--- a/schema/SoftwareSession.schema.yaml
+++ b/schema/SoftwareSession.schema.yaml
@@ -4,7 +4,8 @@ extends: Thing
 role: primary
 status: experimental
 description: |
-  Represents a runtime session with the resources and image that is required by software to execute.
+  Represents a runtime session with the resources and image that
+  is required by software to execute.
 properties:
   volumeMounts:
     '@id': stencila:volumeMount
@@ -14,10 +15,12 @@ properties:
       - $ref: Mount
   cpuResource:
     '@id': stencila:cpuResource
+    description: The CPU resource for the session.
     allOf:
       - $ref: ResourceParameters
   memoryResource:
     '@id': stencila:memoryResource
+    description: The memory resource for the session.
     allOf:
       - $ref: ResourceParameters
   environment:

--- a/schema/SoftwareSourceCode.schema.yaml
+++ b/schema/SoftwareSourceCode.schema.yaml
@@ -9,7 +9,8 @@ properties:
   codeRepository:
     '@id': schema:codeRepository
     description: |
-      Link to the repository where the un-compiled, human readable code and related code is located (SVN, github, CodePlex)
+      Link to the repository where the un-compiled, human readable code and related
+      code is located.
     type: string
     format: uri
   codeSampleType:
@@ -33,17 +34,14 @@ properties:
   runtimePlatform:
     '@id': schema:runtimePlatform
     description: |
-      Runtime platform or script interpreter dependencies (Example - Java v1, Python2.3, .Net Framework 3.0).
+      Runtime platform or script interpreter dependencies (Example - Java v1,
+      Python2.3, .Net Framework 3.0).
     type: array
     items:
       - type: string
   softwareRequirements:
     '@id': schema:softwareRequirements
-    description: |
-      Component dependency requirements for application.
-      This includes runtime environments and shared libraries that
-      are not included in the application distribution package, but
-      required to run the application (Examples include DirectX, Java or .NET runtime).
+    description: Dependency requirements for the software.
     type: array
     items:
       anyOf:
@@ -53,8 +51,7 @@ properties:
   targetProducts:
     '@id': schema:targetProduct
     description: |
-      Target Operating System / Product to which the code applies.
-      If applies to several versions, just the product name can be used.
+      Target operating system or product to which the code applies.
     type: array
     items:
       - $ref: SoftwareApplication

--- a/schema/Strong.schema.yaml
+++ b/schema/Strong.schema.yaml
@@ -3,10 +3,5 @@ title: Strong
 extends: Mark
 role: secondary
 status: stable
-description: |
-  Strongly emphasised content. Analagous to,
-    - JATS [`<bold>`](https://jats.nlm.nih.gov/archiving/tag-library/1.1/element/bold.html)
-    - HTML [`<strong>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strong)
-    - MDAST [`Strong`](https://github.com/syntax-tree/mdast#strong)
-    - Pandoc [`Strong`](https://github.com/jgm/pandoc-types/blob/1.17.5.4/Text/Pandoc/Definition.hs#L257)
+description: Strongly emphasised content.
 properties: {}

--- a/schema/Subscript.schema.yaml
+++ b/schema/Subscript.schema.yaml
@@ -3,9 +3,5 @@ title: Subscript
 extends: Mark
 role: secondary
 status: stable
-description: |
-  Subscripted content. Analagous to,
-    - JATS [`<sub>`](https://jats.nlm.nih.gov/archiving/tag-library/1.1/element/sub.html)
-    - HTML [`<sub>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sub)
-    - Pandoc [`Subscript`](https://github.com/jgm/pandoc-types/blob/1.17.5.4/Text/Pandoc/Definition.hs#L260)
+description: Subscripted content.
 properties: {}

--- a/schema/Superscript.schema.yaml
+++ b/schema/Superscript.schema.yaml
@@ -3,9 +3,5 @@ title: Superscript
 extends: Mark
 role: secondary
 status: stable
-description: |
-  Superscripted content. Analagous to,
-    - JATS [`<sup>`](https://jats.nlm.nih.gov/archiving/tag-library/1.1/element/sup.html)
-    - HTML [`<sup>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sup)
-    - Pandoc [`Superscript`](https://github.com/jgm/pandoc-types/blob/1.17.5.4/Text/Pandoc/Definition.hs#L259)
+description: Superscripted content.
 properties: {}

--- a/schema/TableCell.schema.yaml
+++ b/schema/TableCell.schema.yaml
@@ -9,7 +9,9 @@ properties:
   name:
     '@id': schema:name
     description: |
-      The name of the cell. Cell's have an implicit name derived from their position in the table
+      The name of the cell.
+    $comment: |
+      Cell's have an implicit name derived from their position in the table
       e.g. `C4` for the cell in the third column and fourth row. However this name can be overridden
       with an explicit name, e.g. `rate`.
     type: string

--- a/schema/Thing.schema.yaml
+++ b/schema/Thing.schema.yaml
@@ -2,7 +2,7 @@ title: Thing
 '@id': schema:Thing
 extends: Entity
 status: unstable
-description: The most generic type of item https://schema.org/Thing.
+description: The most generic type of item.
 properties:
   alternateNames:
     '@id': schema:alternateName

--- a/schema/VideoObject.schema.yaml
+++ b/schema/VideoObject.schema.yaml
@@ -3,22 +3,18 @@ title: VideoObject
 extends: MediaObject
 role: secondary
 status: stable
-description: |
-  A video file. https://schema.org/VideoObject
+description: A video file.
 properties:
   caption:
     '@id': schema:caption
-    description: |
-      The caption for this video recording.
+    description: The caption for this video recording.
     type: string
   thumbnail:
     '@id': schema:thumbnail
-    description: |
-      Thumbnail image of this video recording.
+    description: Thumbnail image of this video recording.
     allOf:
       - $ref: ImageObject
   transcript:
     '@id': schema:transcript
-    description: |
-      The transcript of this video recording.
+    description: The transcript of this video recording.
     type: string

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,0 +1,24 @@
+/**
+ * Log configuration for development scripts in this repo.
+ *
+ * To get `DEBUG` level log entries, set the `DEBUG` env var. e.g
+ *
+ * ```bash
+ * DEBUG=1 npx ts-node src/schema.ts
+ * ```
+ */
+
+import * as logga from '@stencila/logga'
+
+logga.replaceHandlers(
+  (data: logga.LogData): void => {
+    if (data.level <= (process.env.DEBUG !== undefined ? 3 : 2)) {
+      // Don't print noisy stack traces
+      data.stack = ''
+      logga.defaultHandler(data)
+    }
+  }
+)
+
+const log = logga.getLogger('schema')
+export default log

--- a/src/schema.d.ts
+++ b/src/schema.d.ts
@@ -20,6 +20,12 @@ import { JSONSchema7, JSONSchema7Definition } from 'json-schema'
  */
 export default interface Schema extends JSONSchema7 {
   /**
+   * The id for the type or property schema to be used
+   * when generating JSON-LD.
+   */
+  '@id'?: string
+
+  /**
    * The role that this schema has.
    */
   role?: 'base' | 'primary' | 'secondary' | 'tertiary'

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -75,13 +75,11 @@ export const build = async (): Promise<void> => {
 if (module.parent === null) build()
 
 /**
- * Check that a schema is valid:
+ * Check that a schema is valid, including that,
  *
  * - is valid JSON Schema v7
- * - all type schemas (those with `properties`):
- *    - have a `@id` and `description`
- * - all property schemas (those that define a property)
- *    - have a `@id` and the `@id` is not used on another property having a different name
+ * - all type schemas (those with `properties`) have a `@id` and `description`
+ * - all property schemas (those that define a property) have a `@id` and `description`
  * - that other schemas that are referred to in `extends` or `$ref` exist
  *
  * @param schemas A map of all the schemas

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -46,8 +46,9 @@ export const build = async (): Promise<void> => {
   const schemata = Array.from(schemas.values())
 
   // Check each schema is valid
-  const fails = schemata.map(schema => checkSchema(schemas, schema))
-          .reduce((fails, ok) => !ok ? fails + 1 : fails, 0)
+  const fails = schemata
+    .map(schema => checkSchema(schemas, schema))
+    .reduce((fails, ok) => (!ok ? fails + 1 : fails), 0)
   if (fails > 0) {
     log.error(`Errors in ${fails} schemas, please see messages above`)
     // Exit with code 1 so that this fails on CI or elsewhere
@@ -91,7 +92,7 @@ const checkSchema = (schemas: Map<string, Schema>, schema: Schema): boolean => {
   const { title, extends: extends_, description, properties } = schema
   log.debug(`Checking type schema "${title}".`)
 
-  const error = (message: string) => {
+  const error = (message: string): void => {
     log.error(message)
     valid = false
   }
@@ -110,20 +111,18 @@ const checkSchema = (schemas: Map<string, Schema>, schema: Schema): boolean => {
     error(`${title} is not a valid JSON Schema:\n${message}`)
   }
 
-  const max_description_length = 120
+  const maxDescriptionLength = 120
 
   // All schemas should have a description
-  if (description === undefined)
-    error(`${title} is missing description`)
-  else if (description.length > max_description_length)
+  if (description === undefined) error(`${title} is missing description`)
+  else if (description.length > maxDescriptionLength)
     error(`${title}.description is too long`)
 
   // Type schemas have necessary properties and extends is valid
   if (properties !== undefined) {
-    if (schema['@id'] === undefined)
-      error(`${title} is missing @id`)
+    if (schema['@id'] === undefined) error(`${title} is missing @id`)
 
-    if (extends_ !== undefined){
+    if (extends_ !== undefined) {
       if (!schemas.has(extends_))
         error(`${title}.extends refers to unknown type "${extends_}`)
     }
@@ -135,7 +134,7 @@ const checkSchema = (schemas: Map<string, Schema>, schema: Schema): boolean => {
 
       if (property.description === undefined)
         error(`${title}.${name} is missing description`)
-      else if (property.description.length > max_description_length)
+      else if (property.description.length > maxDescriptionLength)
         error(`${title}.${name}.description is too long`)
     }
   }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -139,6 +139,22 @@ const checkSchema = (schemas: Map<string, Schema>, schema: Schema): boolean => {
     }
   }
 
+  // Check $refs are valid
+  const walk = (node: Schema): void => {
+    if (typeof node !== 'object') return
+    for (const [key, child] of Object.entries(node)) {
+      if (
+        key === '$ref' &&
+        typeof child === 'string' &&
+        !schemas.has(child)
+      ) {
+        error(`${title} has a $ref to unknown type "${child}"`)
+      }
+      walk(child)
+    }
+  }
+  walk(schema)
+
   return valid
 }
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,5 +1,6 @@
 /**
- * Generate JSON Schema files.
+ * Check `schema/*.schema.yaml` files and generate `built/*.schema.json`
+ * from them.
  */
 
 import fs from 'fs-extra'
@@ -8,9 +9,18 @@ import yaml from 'js-yaml'
 import path from 'path'
 import cloneDeep from 'lodash.clonedeep'
 import Schema from './schema.d'
+import log from './log'
+import Ajv from 'ajv'
+import betterAjvErrors from 'better-ajv-errors'
 
 const SCHEMA_SOURCE_DIR = path.join(__dirname, '..', 'schema')
 const SCHEMA_DEST_DIR = path.join(__dirname, '..', 'built')
+
+// Create a validation function for JSON Schema for use in `checkSchema`
+const ajv = new Ajv({ jsonPointers: true })
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const metaSchema = require('ajv/lib/refs/json-schema-draft-07.json')
+const validateSchema = ajv.compile(metaSchema)
 
 /**
  * Generate `built/*.schema.json` files from `schema/*.schema.yaml` files.
@@ -33,9 +43,19 @@ export const build = async (): Promise<void> => {
       )
     )
   )
+  const schemata = Array.from(schemas.values())
+
+  // Check each schema is valid
+  const fails = schemata.map(schema => checkSchema(schemas, schema))
+          .reduce((fails, ok) => !ok ? fails + 1 : fails, 0)
+  if (fails > 0) {
+    log.error(`Errors in ${fails} schemas, please see messages above`)
+    // Exit with code 1 so that this fails on CI or elsewhere
+    process.exit(1)
+  }
 
   // Process each of the schemas
-  Array.from(schemas.values()).forEach(schema => processSchema(schemas, schema))
+  schemata.forEach(schema => processSchema(schemas, schema))
 
   // Write to destination
   await fs.ensureDir('built')
@@ -54,11 +74,82 @@ export const build = async (): Promise<void> => {
 if (module.parent === null) build()
 
 /**
+ * Check that a schema is valid:
+ *
+ * - is valid JSON Schema v7
+ * - all type schemas (those with `properties`):
+ *    - have a `@id` and `description`
+ * - all property schemas (those that define a property)
+ *    - have a `@id` and the `@id` is not used on another property having a different name
+ * - that other schemas that are referred to in `extends` or `$ref` exist
+ *
+ * @param schemas A map of all the schemas
+ * @param schema The schema being checked
+ */
+const checkSchema = (schemas: Map<string, Schema>, schema: Schema): boolean => {
+  let valid = true
+  const { title, extends: extends_, description, properties } = schema
+  log.debug(`Checking type schema "${title}".`)
+
+  const error = (message: string) => {
+    log.error(message)
+    valid = false
+  }
+
+  // Is a valid schema?
+  if (validateSchema(schema) !== true) {
+    const message = (betterAjvErrors(
+      metaSchema,
+      schema,
+      validateSchema.errors,
+      {
+        format: 'cli',
+        indent: 2
+      }
+    ) as unknown) as string
+    error(`${title} is not a valid JSON Schema:\n${message}`)
+  }
+
+  const max_description_length = 120
+
+  // All schemas should have a description
+  if (description === undefined)
+    error(`${title} is missing description`)
+  else if (description.length > max_description_length)
+    error(`${title}.description is too long`)
+
+  // Type schemas have necessary properties and extends is valid
+  if (properties !== undefined) {
+    if (schema['@id'] === undefined)
+      error(`${title} is missing @id`)
+
+    if (extends_ !== undefined){
+      if (!schemas.has(extends_))
+        error(`${title}.extends refers to unknown type "${extends_}`)
+    }
+
+    // Property schemas have necessary properties
+    for (const [name, property] of Object.entries(properties)) {
+      if (property['@id'] === undefined)
+        error(`${title}.${name} is missing @id`)
+
+      if (property.description === undefined)
+        error(`${title}.${name} is missing description`)
+      else if (property.description.length > max_description_length)
+        error(`${title}.${name}.description is too long`)
+    }
+  }
+
+  return valid
+}
+
+/**
  * Process a schema object to implement inheritance and
  * add add derived properties.
  */
 const processSchema = (schemas: Map<string, Schema>, schema: Schema): void => {
   const { $schema, $id, title, file, source, children, descendants } = schema
+  log.debug(`Processing type schema "${title}".`)
 
   // If it's already got a children and descendants, then it's been processed.
   if (children !== undefined && descendants !== undefined) return

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -141,11 +141,7 @@ const checkSchema = (schemas: Map<string, Schema>, schema: Schema): boolean => {
   const walk = (node: Schema): void => {
     if (typeof node !== 'object') return
     for (const [key, child] of Object.entries(node)) {
-      if (
-        key === '$ref' &&
-        typeof child === 'string' &&
-        !schemas.has(child)
-      ) {
+      if (key === '$ref' && typeof child === 'string' && !schemas.has(child)) {
         error(`${title} has a $ref to unknown type "${child}"`)
       }
       walk(child)

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -51,7 +51,9 @@ if (module.parent === null) build()
  * and can be used to get a type from its name at compile time.
  */
 export const typesInterface = (schemas: Schema[]): string => {
-  return `export interface Types {\n${schemas.map(({title}) => `  ${title}: ${title}`).join('\n')}\n}`
+  return `export interface Types {\n${schemas
+    .map(({ title }) => `  ${title}: ${title}`)
+    .join('\n')}\n}`
 }
 
 /**

--- a/tests/__file_snapshots__/BlockContent.R
+++ b/tests/__file_snapshots__/BlockContent.R
@@ -1,4 +1,4 @@
-#` Block content.
+#` Union type for valid block content.
 #`
 #` @export
 BlockContent = Union("CodeBlock", "CodeChunk", "Heading", "List", "ListItem", "Paragraph", "QuoteBlock", "Table", "ThematicBreak")

--- a/tests/__file_snapshots__/BlockContent.py
+++ b/tests/__file_snapshots__/BlockContent.py
@@ -1,4 +1,4 @@
 """
-Block content.
+Union type for valid block content.
 """
 BlockContent = Union["CodeBlock", "CodeChunk", "Heading", "List", "ListItem", "Paragraph", "QuoteBlock", "Table", "ThematicBreak"]

--- a/tests/__file_snapshots__/BlockContent.ts
+++ b/tests/__file_snapshots__/BlockContent.ts
@@ -1,5 +1,5 @@
 /**
- * Block content.
+ * Union type for valid block content.
  */
 export type BlockContent = CodeBlock | CodeChunk | Heading | List | ListItem | Paragraph | QuoteBlock | Table | ThematicBreak
 

--- a/tests/__file_snapshots__/Person.R
+++ b/tests/__file_snapshots__/Person.R
@@ -1,13 +1,13 @@
-#` A person (alive, dead, undead, or fictional). https://schema.org/Person.
+#` A person (alive, dead, undead, or fictional).
 #`
 #` @param  address Postal address for the person.
 #` @param  affiliations Organizations that the person is affiliated with.
 #` @param  alternateNames Alternate names (aliases) for the item.
 #` @param  description A description of the item.
 #` @param  emails Email addresses for the person.
-#` @param  familyNames Family name. In the U.S., the last name of an Person. This can be used along with givenName instead of the name property.
+#` @param  familyNames Family name. In the U.S., the last name of a person.
 #` @param  funders A person or organization that supports (sponsors) something through some kind of financial contribution.
-#` @param  givenNames Given name. In the U.S., the first name of a Person. This can be used along with familyName instead of the name property.
+#` @param  givenNames Given name. In the U.S., the first name of a person.
 #` @param  honorificPrefix An honorific prefix preceding a person's name such as Dr/Mrs/Mr.
 #` @param  honorificSuffix An honorific suffix after a person's name such as MD/PhD/MSCSW.
 #` @param  id The identifier for this item.

--- a/tests/__file_snapshots__/Person.py
+++ b/tests/__file_snapshots__/Person.py
@@ -1,7 +1,5 @@
 class Person(Thing):
-    """
-    A person (alive, dead, undead, or fictional). https://schema.org/Person.
-    """
+    """A person (alive, dead, undead, or fictional)."""
 
     address: Optional[str]
     affiliations: Optional[Array["Organization"]]

--- a/tests/__file_snapshots__/Person.ts
+++ b/tests/__file_snapshots__/Person.ts
@@ -1,5 +1,5 @@
 /**
- * A person (alive, dead, undead, or fictional). https://schema.org/Person.
+ * A person (alive, dead, undead, or fictional).
  */
 export interface Person extends Thing {
   type: 'Person'

--- a/tests/__file_snapshots__/Thing.ts
+++ b/tests/__file_snapshots__/Thing.ts
@@ -1,5 +1,5 @@
 /**
- * The most generic type of item https://schema.org/Thing.
+ * The most generic type of item.
  */
 export interface Thing extends Entity {
   type: 'Thing' | 'Article' | 'AudioObject' | 'Brand' | 'Code' | 'CodeBlock' | 'CodeChunk' | 'CodeExpr' | 'Collection' | 'ContactPoint' | 'CreativeWork' | 'Datatable' | 'DatatableColumn' | 'Environment' | 'ImageObject' | 'MediaObject' | 'Mount' | 'Organization' | 'Person' | 'Product' | 'ResourceParameters' | 'SoftwareApplication' | 'SoftwareSession' | 'SoftwareSourceCode' | 'Table' | 'VideoObject'

--- a/util/type-maps.ts
+++ b/util/type-maps.ts
@@ -1,7 +1,23 @@
-import { BlockContent, CreativeWork, Delete, Emphasis, InlineContent, Quote, Strong, Subscript, Superscript } from '../types';
-import { TypeMap } from './type-map';
+import {
+  BlockContent,
+  CreativeWork,
+  Delete,
+  Emphasis,
+  InlineContent,
+  Quote,
+  Strong,
+  Subscript,
+  Superscript
+} from '../types'
+import { TypeMap } from './type-map'
 
-export type MarkTypes = Delete | Emphasis | Quote | Strong | Subscript | Superscript
+export type MarkTypes =
+  | Delete
+  | Emphasis
+  | Quote
+  | Strong
+  | Subscript
+  | Superscript
 
 export const markTypes: TypeMap<MarkTypes> = {
   Delete: 'Delete',


### PR DESCRIPTION
Check that a schema is valid, including that,

- is valid JSON Schema v7
- all type schemas (those with `properties`) have a `@id` and `description`
- all property schemas (those that define a property) have a `@id` and `description`
- that other schemas that are referred to in `extends` or `$ref` exist

Fixes current schemas so that they pass these checks.