### PR TITLE
Speed up R build on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,11 @@ matrix:
     - language: r
       r: release
 
-      install:
-        - make -C r setup
+      r_binary_packages:
+        - covr
+        - lintr
+        - roxygen
+        - testthat
 
       script:
         - make -C r lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ matrix:
       r_binary_packages:
         - covr
         - lintr
-        - roxygen
+        - roxygen2
         - testthat
 
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,9 +63,9 @@ matrix:
         - cd r
 
       script:
-        - make -C r lint
-        - make -C r test
-        - make -C r build
+        - make lint
+        - make test
+        - make build
 
       after_success:
         - cd r && Rscript -e 'covr::codecov()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,9 +53,11 @@ matrix:
 
       r_binary_packages:
         - covr
-        - lintr
         - roxygen2
         - testthat
+
+      r_github_packages:
+        - jimhester/lintr
 
       before_install:
         - cd r

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,9 @@ matrix:
           on:
             branch: master
 
-    - dist: xenial
-      language: python
+    - language: python
       python: '3.7'
+      dist: xenial
 
       install:
         - make -C py setup
@@ -48,6 +48,7 @@ matrix:
 
     - language: r
       r: release
+      dist: xenial
 
       r_binary_packages:
         - covr

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ matrix:
     - language: r
       r: release
       dist: xenial
+      sudo: true
 
       r_binary_packages:
         - covr

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,9 @@ matrix:
         - roxygen
         - testthat
 
+      before_install:
+        - cd r
+
       script:
         - make -C r lint
         - make -C r test

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,4 +68,4 @@ matrix:
         - make build
 
       after_success:
-        - cd r && Rscript -e 'covr::codecov()'
+        - Rscript -e 'covr::codecov()'


### PR DESCRIPTION
This reduces lint/test/build time of the R package from about 8 mins to about 6 mins. Not a great improvement, but the best that seems possible given dev packages required.