### PR TITLE
feat(Typescript): Add a more convienient single-type type guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,11 @@
     }
   },
   "eslintConfig": {
-    "extends": "@stencila/eslint-config"
+    "extends": "@stencila/eslint-config",
+    "env": {
+      "node": true,
+      "jest": true
+    }
   },
   "eslintIgnore": [
     "built",

--- a/ts/util/__tests__/guards.test.ts
+++ b/ts/util/__tests__/guards.test.ts
@@ -1,16 +1,14 @@
-import { TypeMap } from '../type-map'
-
-import { blockContentTypes, inlineContentTypes } from '../type-maps'
-
 import {
+  isA,
   isInlineContent,
   isInlineEntity,
   isPrimitive,
-  typeIs,
+  isType,
   nodeIs,
-  isA,
-  isType
+  typeIs
 } from '../guards'
+import { TypeMap } from '../type-map'
+import { blockContentTypes, inlineContentTypes } from '../type-maps'
 
 const primitives = [null, true, false, NaN, 2, 'string']
 
@@ -68,17 +66,17 @@ describe('isA', () => {
   })
 
   test('it returns true for the right type', () => {
-    expect(isA(person, 'Person')).toBe(true)
-    expect(isA(para, 'Paragraph')).toBe(true)
+    expect(isA('Person', person)).toBe(true)
+    expect(isA('Paragraph', para)).toBe(true)
   })
 
   test('it returns false for the wrong type', () => {
-    expect(isA(para, 'Person')).toBe(false)
-    expect(isA(null, 'Person')).toBe(false)
-    expect(isA(true, 'Person')).toBe(false)
-    expect(isA(1.0, 'Person')).toBe(false)
-    expect(isA([], 'Person')).toBe(false)
-    expect(isA({ type: 'Foo' }, 'Person')).toBe(false)
+    expect(isA('Person', para)).toBe(false)
+    expect(isA('Person', null)).toBe(false)
+    expect(isA('Person', true)).toBe(false)
+    expect(isA('Person', 1.0)).toBe(false)
+    expect(isA('Person', [])).toBe(false)
+    expect(isA('Person', { type: 'Foo' })).toBe(false)
   })
 })
 

--- a/ts/util/__tests__/guards.test.ts
+++ b/ts/util/__tests__/guards.test.ts
@@ -8,7 +8,8 @@ import {
   isPrimitive,
   typeIs,
   nodeIs,
-  isa
+  isA,
+  isType
 } from '../guards'
 
 const primitives = [null, true, false, NaN, 2, 'string']
@@ -56,28 +57,47 @@ describe('nodeIs', () => {
     expect(nodeIs(typeMap)({ type: typeMap.someType })).toBe(true))
 })
 
-describe('isa', () => {
+describe('isA', () => {
   const person = { type: 'Person' }
   const para = { type: 'Paragraph', content: [] }
 
   test('it returns false for undefined types', () => {
     // This is a compile error too
     // @ts-ignore
-    expect(isa(person, 'Foo')).toBe(false)
+    expect(isA(person, 'Foo')).toBe(false)
   })
 
   test('it returns true for the right type', () => {
-    expect(isa(person, 'Person')).toBe(true)
-    expect(isa(para, 'Paragraph')).toBe(true)
+    expect(isA(person, 'Person')).toBe(true)
+    expect(isA(para, 'Paragraph')).toBe(true)
   })
 
   test('it returns false for the wrong type', () => {
-    expect(isa(para, 'Person')).toBe(false)
-    expect(isa(null, 'Person')).toBe(false)
-    expect(isa(true, 'Person')).toBe(false)
-    expect(isa(1.0, 'Person')).toBe(false)
-    expect(isa([], 'Person')).toBe(false)
-    expect(isa({ type: 'Foo' }, 'Person')).toBe(false)
+    expect(isA(para, 'Person')).toBe(false)
+    expect(isA(null, 'Person')).toBe(false)
+    expect(isA(true, 'Person')).toBe(false)
+    expect(isA(1.0, 'Person')).toBe(false)
+    expect(isA([], 'Person')).toBe(false)
+    expect(isA({ type: 'Foo' }, 'Person')).toBe(false)
+  })
+})
+
+describe('isType', () => {
+  const person = { type: 'Person' }
+  const para = { type: 'Paragraph', content: [] }
+
+  test('it returns false for undefined types', () => {
+    // This is a compile error too
+    // @ts-ignore
+    expect(isType('Foo')(person)).toBe(false)
+  })
+
+  test('it returns true for the right type', () => {
+    expect(isType('Person')(person)).toBe(true)
+  })
+
+  test('it returns false for the wrong type', () => {
+    expect(isType('Person')(para)).toBe(false)
   })
 })
 

--- a/ts/util/__tests__/guards.test.ts
+++ b/ts/util/__tests__/guards.test.ts
@@ -7,7 +7,8 @@ import {
   isInlineEntity,
   isPrimitive,
   typeIs,
-  nodeIs
+  nodeIs,
+  isa
 } from '../guards'
 
 const primitives = [null, true, false, NaN, 2, 'string']
@@ -53,6 +54,31 @@ describe('nodeIs', () => {
   test('it returns true for Objects containing a "type" key found in the typeMap', () =>
     // @ts-ignore
     expect(nodeIs(typeMap)({ type: typeMap.someType })).toBe(true))
+})
+
+describe('isa', () => {
+  const person = { type: 'Person' }
+  const para = { type: 'Paragraph', content: [] }
+
+  test('it returns false for undefined types', () => {
+    // This is a compile error too
+    // @ts-ignore
+    expect(isa(person, 'Foo')).toBe(false)
+  })
+
+  test('it returns true for the right type', () => {
+    expect(isa(person, 'Person')).toBe(true)
+    expect(isa(para, 'Paragraph')).toBe(true)
+  })
+
+  test('it returns false for the wrong type', () => {
+    expect(isa(para, 'Person')).toBe(false)
+    expect(isa(null, 'Person')).toBe(false)
+    expect(isa(true, 'Person')).toBe(false)
+    expect(isa(1.0, 'Person')).toBe(false)
+    expect(isa([], 'Person')).toBe(false)
+    expect(isa({ type: 'Foo' }, 'Person')).toBe(false)
+  })
 })
 
 describe('isPrimitive', () => {

--- a/ts/util/guards.ts
+++ b/ts/util/guards.ts
@@ -71,7 +71,7 @@ export const is = <Ts extends Entity>(type: keyof TypeMap<Ts>) => {
  *
  * @param type The type to test for
  */
-export const isa = <K extends keyof Types>(
+export const isA = <K extends keyof Types>(
   node: Node,
   type: K
 ): node is Types[K] => {

--- a/ts/util/guards.ts
+++ b/ts/util/guards.ts
@@ -65,9 +65,11 @@ export const is = <Ts extends Entity>(type: keyof TypeMap<Ts>) => {
 }
 
 /**
- * A type guard to determine whether a node is of a particular type.
+ * A type guard to determine whether a node is of a specific type.
  * Returns a boolean value and narrows the TypeScript inferred type to
  * the type.
+ *
+ * e.g. `isA(node, 'Paragraph')`
  *
  * @param type The type to test for
  */
@@ -76,6 +78,21 @@ export const isA = <K extends keyof Types>(
   type: K
 ): node is Types[K] => {
   return isEntity(node) && node.type === type
+}
+
+/**
+ * Returns a type guard to determine whether a node is of a specific type.
+ * Returns a boolean value and narrows the TypeScript inferred type to
+ * the type.
+ *
+ * e.g. `article.content.filter(isType('Paragraph'))`
+ *
+ * @param type The type to test for
+ */
+export const isType = <K extends keyof Types>(type: K) => (
+  node?: Node
+): node is Types[K] => {
+  return node !== undefined && isA(node, type)
 }
 
 /**

--- a/ts/util/guards.ts
+++ b/ts/util/guards.ts
@@ -74,8 +74,8 @@ export const is = <Ts extends Entity>(type: keyof TypeMap<Ts>) => {
  * @param type The type to test for
  */
 export const isA = <K extends keyof Types>(
-  node: Node,
-  type: K
+  type: K,
+  node: Node
 ): node is Types[K] => {
   return isEntity(node) && node.type === type
 }
@@ -92,7 +92,7 @@ export const isA = <K extends keyof Types>(
 export const isType = <K extends keyof Types>(type: K) => (
   node?: Node
 ): node is Types[K] => {
-  return node !== undefined && isA(node, type)
+  return node !== undefined && isA(type, node)
 }
 
 /**

--- a/ts/util/guards.ts
+++ b/ts/util/guards.ts
@@ -4,7 +4,8 @@ import {
   InlineContent,
   ListItem,
   Node,
-  Paragraph
+  Paragraph,
+  Types
 } from '../types'
 import { TypeMap, TypeMapGeneric } from './type-map'
 import {
@@ -52,7 +53,7 @@ export const nodeIs = <T extends Partial<TypeMap | TypeMapGeneric>>(
  * Returns a boolean value and narrows the TypeScript inferred type to
  * the type.
  *
- * @param type The type to test the
+ * @param type The type to test for
  */
 // eslint-disable-next-line
 export const is = <Ts extends Entity>(type: keyof TypeMap<Ts>) => {
@@ -61,6 +62,20 @@ export const is = <Ts extends Entity>(type: keyof TypeMap<Ts>) => {
     [type]: type
   }
   return nodeIs(typeMap)
+}
+
+/**
+ * A type guard to determine whether a node is of a particular type.
+ * Returns a boolean value and narrows the TypeScript inferred type to
+ * the type.
+ *
+ * @param type The type to test for
+ */
+export const isa = <K extends keyof Types>(
+  node: Node,
+  type: K
+): node is Types[K] => {
+  return isEntity(node) && node.type === type
 }
 
 /**


### PR DESCRIPTION
Closes #115.

Added `isa` function. Might be better named `isType`. There may be a better implementation.