### PR TITLE
Avoid package.json regressions when installing on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ jobs:
         - npm run build
         - npm run test
         - npm run docs
+        # Clear package.json overrides made when installing @stencila/dev-config
+        - git checkout package.json
 
       after_success:
         - bash <(curl -s https://codecov.io/bash) -cF ts

--- a/package.json
+++ b/package.json
@@ -101,7 +101,11 @@
     }
   },
   "eslintConfig": {
-    "extends": "@stencila/eslint-config"
+    "extends": "@stencila/eslint-config",
+    "env": {
+      "node": true,
+      "jest": true
+    }
   },
   "eslintIgnore": [
     "built",
@@ -111,11 +115,13 @@
   "husky": {
     "hooks": {
       "pre-commit": "pretty-quick --staged",
+      "pre-push": "make checkBindings",
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
   },
   "prettier": "@stencila/dev-config/prettier-config.json",
   "release": {
-    "extends": "@stencila/semantic-release-config"
+    "extends": "@stencila/semantic-release-config",
+    "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
   }
 }


### PR DESCRIPTION
When installing `@stencila/dev-config` we run some post-install scripts to [update the dependant package's `package.json`](https://github.com/stencila/dev-config/tree/master/packages/dev-config#install) file. Locally it's not too much of an issue since a user can compare and keep/discard the changes. However on CI this ended up [reverting some changes](https://github.com/stencila/schema/commit/c4da990d53fbd83718a52d703e702c075d02c30e) made to the package.json file.

This PR adds a step on CI to discard any changes to package.json file before running any release/deploy steps.