### PR TITLE
Add content field to Cite schema

### DIFF
--- a/py/stencila/schema/types.py
+++ b/py/stencila/schema/types.py
@@ -39,6 +39,7 @@ class Cite(Entity):
 
     target: str
     citationMode: Optional["Enum0"]
+    content: Optional[Array["InlineContent"]]
     pageEnd: Optional[Union[str, int]]
     pageStart: Optional[Union[str, int]]
     pagination: Optional[str]
@@ -49,6 +50,7 @@ class Cite(Entity):
         self,
         target: str,
         citationMode: Optional["Enum0"] = None,
+        content: Optional[Array["InlineContent"]] = None,
         id: Optional[str] = None,
         meta: Optional[Dict[str, Any]] = None,
         pageEnd: Optional[Union[str, int]] = None,
@@ -65,6 +67,8 @@ class Cite(Entity):
             self.target = target
         if citationMode is not None:
             self.citationMode = citationMode
+        if content is not None:
+            self.content = content
         if pageEnd is not None:
             self.pageEnd = pageEnd
         if pageStart is not None:

--- a/r/R/types.R
+++ b/r/R/types.R
@@ -27,6 +27,7 @@ Entity <- function(
 #' @name Cite
 #' @param target The target of the citation (URL or reference ID). \bold{Required}.
 #' @param citationMode How the cite is rendered in the surrounding text.
+#' @param content Optional structured content/text of this citation.
 #' @param id The identifier for this item.
 #' @param meta Metadata associated with this item.
 #' @param pageEnd The page on which the work ends; for example "138" or "xvi".
@@ -39,6 +40,7 @@ Entity <- function(
 Cite <- function(
   target,
   citationMode,
+  content,
   id,
   meta,
   pageEnd,
@@ -54,6 +56,7 @@ Cite <- function(
   self$type <- as_scalar("Cite")
   self[["target"]] <- check_property("Cite", "target", TRUE, missing(target), "character", target)
   self[["citationMode"]] <- check_property("Cite", "citationMode", FALSE, missing(citationMode), Enum("normal", "suppressAuthor"), citationMode)
+  self[["content"]] <- check_property("Cite", "content", FALSE, missing(content), Array("InlineContent"), content)
   self[["pageEnd"]] <- check_property("Cite", "pageEnd", FALSE, missing(pageEnd), Union("character", "numeric"), pageEnd)
   self[["pageStart"]] <- check_property("Cite", "pageStart", FALSE, missing(pageStart), Union("character", "numeric"), pageStart)
   self[["pagination"]] <- check_property("Cite", "pagination", FALSE, missing(pagination), "character", pagination)

--- a/schema/Cite.schema.yaml
+++ b/schema/Cite.schema.yaml
@@ -13,6 +13,12 @@ properties:
     enum:
       - normal
       - suppressAuthor
+  content:
+    '@id': stencila:content
+    description: Optional structured content/text of this citation.
+    type: array
+    items:
+      $ref: InlineContent
   pageStart:
     '@id': schema:pageStart
     description: The page on which the work starts; for example "135" or "xiii".


### PR DESCRIPTION
Closes #133 

I didn't change the `target` prop to allow for holding either `string` or `CreativeWork`. After reading the reasoning for omitting the `content` prop, I think it doesn't make sense to have the CreativeWork content both in references and the cite node.
Let me know if someone feels otherwise :)

