### PR TITLE
feat(Math): Add Math, MathFragment and MathBlock node types

### DIFF
--- a/py/stencila/schema/types.py
+++ b/py/stencila/schema/types.py
@@ -1361,6 +1361,69 @@ class ListItem(Entity):
             self.checked = checked
 
 
+class Math(Entity):
+    """A mathematical variable or equation."""
+
+    text: str
+    mathLanguage: Optional[str] = None
+
+    def __init__(
+        self,
+        text: str,
+        id: Optional[str] = None,
+        mathLanguage: Optional[str] = None,
+        meta: Optional[Dict[str, Any]] = None
+    ) -> None:
+        super().__init__(
+            id=id,
+            meta=meta
+        )
+        if text is not None:
+            self.text = text
+        if mathLanguage is not None:
+            self.mathLanguage = mathLanguage
+
+
+class MathBlock(Math):
+    """A block of math, e.g an equation, to be treated as block content."""
+
+    def __init__(
+        self,
+        text: str,
+        id: Optional[str] = None,
+        mathLanguage: Optional[str] = None,
+        meta: Optional[Dict[str, Any]] = None
+    ) -> None:
+        super().__init__(
+            text=text,
+            id=id,
+            mathLanguage=mathLanguage,
+            meta=meta
+        )
+
+
+
+class MathFragment(Math):
+    """
+    A fragment of math, e.g a variable name, to be treated as inline content.
+    """
+
+    def __init__(
+        self,
+        text: str,
+        id: Optional[str] = None,
+        mathLanguage: Optional[str] = None,
+        meta: Optional[Dict[str, Any]] = None
+    ) -> None:
+        super().__init__(
+            text=text,
+            id=id,
+            mathLanguage=mathLanguage,
+            meta=meta
+        )
+
+
+
 class Organization(Thing):
     """An organization such as a school, NGO, corporation, club, etc."""
 
@@ -2493,7 +2556,7 @@ class VolumeMount(Thing):
 """
 Union type for valid block content.
 """
-BlockContent = Union["CodeBlock", "CodeChunk", "Heading", "List", "ListItem", "Paragraph", "QuoteBlock", "Table", "ThematicBreak"]
+BlockContent = Union["CodeBlock", "CodeChunk", "Heading", "List", "ListItem", "MathBlock", "Paragraph", "QuoteBlock", "Table", "ThematicBreak"]
 
 
 """
@@ -2523,19 +2586,25 @@ CreativeWorkTypes = Union["CreativeWork", "Article", "AudioObject", "Collection"
 """
 All type schemas that are derived from Entity
 """
-EntityTypes = Union["Entity", "ArraySchema", "Article", "AudioObject", "BooleanSchema", "Brand", "Cite", "CiteGroup", "Code", "CodeBlock", "CodeChunk", "CodeError", "CodeExpression", "CodeFragment", "Collection", "ConstantSchema", "ContactPoint", "CreativeWork", "Datatable", "DatatableColumn", "Date", "Delete", "Emphasis", "EnumSchema", "Figure", "Function", "Heading", "ImageObject", "Include", "IntegerSchema", "Link", "List", "ListItem", "Mark", "MediaObject", "NumberSchema", "Organization", "Paragraph", "Parameter", "Periodical", "Person", "Product", "PublicationIssue", "PublicationVolume", "Quote", "QuoteBlock", "SoftwareApplication", "SoftwareEnvironment", "SoftwareSession", "SoftwareSourceCode", "StringSchema", "Strong", "Subscript", "Superscript", "Table", "TableCell", "TableRow", "ThematicBreak", "Thing", "TupleSchema", "Variable", "VideoObject", "VolumeMount"]
+EntityTypes = Union["Entity", "ArraySchema", "Article", "AudioObject", "BooleanSchema", "Brand", "Cite", "CiteGroup", "Code", "CodeBlock", "CodeChunk", "CodeError", "CodeExpression", "CodeFragment", "Collection", "ConstantSchema", "ContactPoint", "CreativeWork", "Datatable", "DatatableColumn", "Date", "Delete", "Emphasis", "EnumSchema", "Figure", "Function", "Heading", "ImageObject", "Include", "IntegerSchema", "Link", "List", "ListItem", "Mark", "Math", "MathBlock", "MathFragment", "MediaObject", "NumberSchema", "Organization", "Paragraph", "Parameter", "Periodical", "Person", "Product", "PublicationIssue", "PublicationVolume", "Quote", "QuoteBlock", "SoftwareApplication", "SoftwareEnvironment", "SoftwareSession", "SoftwareSourceCode", "StringSchema", "Strong", "Subscript", "Superscript", "Table", "TableCell", "TableRow", "ThematicBreak", "Thing", "TupleSchema", "Variable", "VideoObject", "VolumeMount"]
 
 
 """
 Union type for valid inline content.
 """
-InlineContent = Union[None, bool, int, float, str, "CodeFragment", "CodeExpression", "Delete", "Emphasis", "ImageObject", "Link", "Quote", "Strong", "Subscript", "Superscript", "Cite", "CiteGroup"]
+InlineContent = Union[None, bool, int, float, str, "CodeFragment", "CodeExpression", "Delete", "Emphasis", "ImageObject", "Link", "MathFragment", "Quote", "Strong", "Subscript", "Superscript", "Cite", "CiteGroup"]
 
 
 """
 All type schemas that are derived from Mark
 """
 MarkTypes = Union["Mark", "Delete", "Emphasis", "Quote", "Strong", "Subscript", "Superscript"]
+
+
+"""
+All type schemas that are derived from Math
+"""
+MathTypes = Union["Math", "MathBlock", "MathFragment"]
 
 
 """

--- a/r/R/types.R
+++ b/r/R/types.R
@@ -1622,6 +1622,89 @@ ListItem <- function(
 }
 
 
+#' A mathematical variable or equation.
+#'
+#' @name Math
+#' @param text The text of the equation in the language. \bold{Required}.
+#' @param id The identifier for this item.
+#' @param mathLanguage The language used for the equation e.g tex, mathml, asciimath.
+#' @param meta Metadata associated with this item.
+#' @seealso \code{\link{Entity}}
+#' @export
+Math <- function(
+  text,
+  id,
+  mathLanguage,
+  meta
+){
+  self <- Entity(
+    id = id,
+    meta = meta
+  )
+  self$type <- as_scalar("Math")
+  self[["text"]] <- check_property("Math", "text", TRUE, missing(text), "character", text)
+  self[["mathLanguage"]] <- check_property("Math", "mathLanguage", FALSE, missing(mathLanguage), "character", mathLanguage)
+  class(self) <- c(class(self), "Math")
+  self
+}
+
+
+#' A block of math, e.g an equation, to be treated as block content.
+#'
+#' @name MathBlock
+#' @param text The text of the equation in the language. \bold{Required}.
+#' @param id The identifier for this item.
+#' @param mathLanguage The language used for the equation e.g tex, mathml, asciimath.
+#' @param meta Metadata associated with this item.
+#' @seealso \code{\link{Math}}
+#' @export
+MathBlock <- function(
+  text,
+  id,
+  mathLanguage,
+  meta
+){
+  self <- Math(
+    text = text,
+    id = id,
+    mathLanguage = mathLanguage,
+    meta = meta
+  )
+  self$type <- as_scalar("MathBlock")
+
+  class(self) <- c(class(self), "MathBlock")
+  self
+}
+
+
+#' A fragment of math, e.g a variable name, to be treated as inline content.
+#'
+#' @name MathFragment
+#' @param text The text of the equation in the language. \bold{Required}.
+#' @param id The identifier for this item.
+#' @param mathLanguage The language used for the equation e.g tex, mathml, asciimath.
+#' @param meta Metadata associated with this item.
+#' @seealso \code{\link{Math}}
+#' @export
+MathFragment <- function(
+  text,
+  id,
+  mathLanguage,
+  meta
+){
+  self <- Math(
+    text = text,
+    id = id,
+    mathLanguage = mathLanguage,
+    meta = meta
+  )
+  self$type <- as_scalar("MathFragment")
+
+  class(self) <- c(class(self), "MathFragment")
+  self
+}
+
+
 #' An organization such as a school, NGO, corporation, club, etc.
 #'
 #' @name Organization
@@ -2978,7 +3061,7 @@ VolumeMount <- function(
 #' Union type for valid block content.
 #'
 #' @export
-BlockContent <- Union(CodeBlock, CodeChunk, Heading, List, ListItem, Paragraph, QuoteBlock, Table, ThematicBreak)
+BlockContent <- Union(CodeBlock, CodeChunk, Heading, List, ListItem, MathBlock, Paragraph, QuoteBlock, Table, ThematicBreak)
 
 
 #' All type schemas that are derived from CodeBlock
@@ -3008,19 +3091,25 @@ CreativeWorkTypes <- Union(CreativeWork, Article, AudioObject, Collection, Datat
 #' All type schemas that are derived from Entity
 #'
 #' @export
-EntityTypes <- Union(Entity, ArraySchema, Article, AudioObject, BooleanSchema, Brand, Cite, CiteGroup, Code, CodeBlock, CodeChunk, CodeError, CodeExpression, CodeFragment, Collection, ConstantSchema, ContactPoint, CreativeWork, Datatable, DatatableColumn, Date, Delete, Emphasis, EnumSchema, Figure, Function, Heading, ImageObject, Include, IntegerSchema, Link, List, ListItem, Mark, MediaObject, NumberSchema, Organization, Paragraph, Parameter, Periodical, Person, Product, PublicationIssue, PublicationVolume, Quote, QuoteBlock, SoftwareApplication, SoftwareEnvironment, SoftwareSession, SoftwareSourceCode, StringSchema, Strong, Subscript, Superscript, Table, TableCell, TableRow, ThematicBreak, Thing, TupleSchema, Variable, VideoObject, VolumeMount)
+EntityTypes <- Union(Entity, ArraySchema, Article, AudioObject, BooleanSchema, Brand, Cite, CiteGroup, Code, CodeBlock, CodeChunk, CodeError, CodeExpression, CodeFragment, Collection, ConstantSchema, ContactPoint, CreativeWork, Datatable, DatatableColumn, Date, Delete, Emphasis, EnumSchema, Figure, Function, Heading, ImageObject, Include, IntegerSchema, Link, List, ListItem, Mark, Math, MathBlock, MathFragment, MediaObject, NumberSchema, Organization, Paragraph, Parameter, Periodical, Person, Product, PublicationIssue, PublicationVolume, Quote, QuoteBlock, SoftwareApplication, SoftwareEnvironment, SoftwareSession, SoftwareSourceCode, StringSchema, Strong, Subscript, Superscript, Table, TableCell, TableRow, ThematicBreak, Thing, TupleSchema, Variable, VideoObject, VolumeMount)
 
 
 #' Union type for valid inline content.
 #'
 #' @export
-InlineContent <- Union("NULL", "logical", "numeric", "character", CodeFragment, CodeExpression, Delete, Emphasis, ImageObject, Link, Quote, Strong, Subscript, Superscript, Cite, CiteGroup)
+InlineContent <- Union("NULL", "logical", "numeric", "character", CodeFragment, CodeExpression, Delete, Emphasis, ImageObject, Link, MathFragment, Quote, Strong, Subscript, Superscript, Cite, CiteGroup)
 
 
 #' All type schemas that are derived from Mark
 #'
 #' @export
 MarkTypes <- Union(Mark, Delete, Emphasis, Quote, Strong, Subscript, Superscript)
+
+
+#' All type schemas that are derived from Math
+#'
+#' @export
+MathTypes <- Union(Math, MathBlock, MathFragment)
 
 
 #' All type schemas that are derived from MediaObject

--- a/schema/BlockContent.schema.yaml
+++ b/schema/BlockContent.schema.yaml
@@ -7,6 +7,7 @@ anyOf:
   - $ref: Heading
   - $ref: List
   - $ref: ListItem
+  - $ref: MathBlock
   - $ref: Paragraph
   - $ref: QuoteBlock
   - $ref: Table

--- a/schema/InlineContent.schema.yaml
+++ b/schema/InlineContent.schema.yaml
@@ -17,6 +17,7 @@ anyOf:
   - $ref: Emphasis
   - $ref: ImageObject
   - $ref: Link
+  - $ref: MathFragment
   - $ref: Quote
   - $ref: Strong
   - $ref: Subscript

--- a/schema/Math.schema.yaml
+++ b/schema/Math.schema.yaml
@@ -1,0 +1,24 @@
+title: Math
+'@id': stencila:Math
+extends: Entity
+role: base
+status: unstable
+category: prose
+description: A mathematical variable or equation.
+$comment: |
+  This is a base type for `MathFragment` and `MathBlock` and should not
+  normally be instantiated.
+  This type has a similar structure and purpose to `Code` which is a base type
+  for `CodeFragment`, `CodeBlock` etc.
+properties:
+  mathLanguage:
+    '@id': schema:mathLanguage
+    description: The language used for the equation e.g tex, mathml, asciimath.
+    type: string
+    default: 'tex'
+  text:
+    '@id': schema:text
+    description: The text of the equation in the language.
+    type: string
+required:
+  - text

--- a/schema/MathBlock.schema.yaml
+++ b/schema/MathBlock.schema.yaml
@@ -1,0 +1,8 @@
+title: MathBlock
+'@id': stencila:MathBlock
+extends: Math
+role: secondary
+status: unstable
+category: prose
+description: A block of math, e.g an equation, to be treated as block content.
+properties: {}

--- a/schema/MathFragment.schema.yaml
+++ b/schema/MathFragment.schema.yaml
@@ -1,0 +1,8 @@
+title: MathFragment
+'@id': stencila:MathFragment
+extends: Math
+role: secondary
+status: unstable
+category: prose
+description: A fragment of math, e.g a variable name, to be treated as inline content.
+properties: {}

--- a/ts/bindings/__file_snapshots__/BlockContent.R
+++ b/ts/bindings/__file_snapshots__/BlockContent.R
@@ -1,5 +1,5 @@
 #' Union type for valid block content.
 #'
 #' @export
-BlockContent <- Union(CodeBlock, CodeChunk, Heading, List, ListItem, Paragraph, QuoteBlock, Table, ThematicBreak)
+BlockContent <- Union(CodeBlock, CodeChunk, Heading, List, ListItem, MathBlock, Paragraph, QuoteBlock, Table, ThematicBreak)
 

--- a/ts/bindings/__file_snapshots__/BlockContent.py
+++ b/ts/bindings/__file_snapshots__/BlockContent.py
@@ -1,4 +1,4 @@
 """
 Union type for valid block content.
 """
-BlockContent = Union["CodeBlock", "CodeChunk", "Heading", "List", "ListItem", "Paragraph", "QuoteBlock", "Table", "ThematicBreak"]
+BlockContent = Union["CodeBlock", "CodeChunk", "Heading", "List", "ListItem", "MathBlock", "Paragraph", "QuoteBlock", "Table", "ThematicBreak"]

--- a/ts/bindings/__file_snapshots__/BlockContent.ts
+++ b/ts/bindings/__file_snapshots__/BlockContent.ts
@@ -1,5 +1,5 @@
 /**
  * Union type for valid block content.
  */
-export type BlockContent = CodeBlock | CodeChunk | Heading | List | ListItem | Paragraph | QuoteBlock | Table | ThematicBreak
+export type BlockContent = CodeBlock | CodeChunk | Heading | List | ListItem | MathBlock | Paragraph | QuoteBlock | Table | ThematicBreak
 


### PR DESCRIPTION
Closes #154. 

There is a sister PR on Encoda, https://github.com/stencila/encoda/pull/383, that does some testing that this structure & hierarchy will work for the Pandoc and HTML codecs.

No documentation added as yet, will wait for acceptance of this PR first.