### PR TITLE
adding start of work for dockerized development environment

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,0 +1,3 @@
+local({r <- getOption("repos")
+       r["CRAN"] <- "http://cran.r-project.org"
+       options(repos=r)})

--- a/.Rprofile
+++ b/.Rprofile
@@ -1,3 +1,0 @@
-local({r <- getOption("repos")
-       r["CRAN"] <- "http://cran.r-project.org"
-       options(repos=r)})

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+# Tell Docker to ignore all files apart from those absolutely needed to setup a
+# development environment.
+# For why this is a good idea see https://codefresh.io/docker-tutorial/not-ignore-dockerignore/
+
+*
+
+!/Makefile
+!/package*.json
+
+!/py/Makefile
+!/py/requirements-dev.txt
+
+!/r/Makefile
+!/r/DESCRIPTION

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:12
+# docker build -t stencila/schema .
+WORKDIR /code
+
+# Install app dependencies
+COPY package*.json ./
+COPY .Rprofile /root/.Rprofile
+
+RUN apt-get update && \
+    apt-get install -y python3-pip r-base && \
+    # RScript -e "devtools::install_github('r-lib/systemfonts')" && \
+    # this can be uncommented and changed to make setup if R deps can be resolved
+    npm install && \
+    npm audit fix
+
+# Bundle app source
+COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
  && apt-get install -y \
+      curl \
+ && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
+ && apt-get update \
+ && apt-get install -y \
       libcurl4-openssl-dev \
       libfontconfig1-dev \
       libfreetype6-dev \
@@ -10,10 +14,11 @@ RUN apt-get update \
       libjpeg-dev \
       libpng-dev \
       libssh2-1-dev \
+      libssl-dev \
       libtiff5-dev \
       libxml2-dev \
       nodejs \
-      npm \
+      pandoc \
       python3 \
       python3-pip \
       r-base \
@@ -22,8 +27,4 @@ RUN apt-get update \
 COPY . /code
 WORKDIR /code
 
-RUN npm install
-RUN make -C py setup
-
-# WIP: Skipping for now, until all system deps are determined and installed.
-# RUN make -C r setup
+RUN make setup

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,29 @@
-FROM node:12
-# docker build -t stencila/schema .
+FROM ubuntu:20.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+ && apt-get install -y \
+      libcurl4-openssl-dev \
+      libfontconfig1-dev \
+      libfreetype6-dev \
+      libgit2-dev \
+      libjpeg-dev \
+      libpng-dev \
+      libssh2-1-dev \
+      libtiff5-dev \
+      libxml2-dev \
+      nodejs \
+      npm \
+      python3 \
+      python3-pip \
+      r-base \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY . /code
 WORKDIR /code
 
-# Install app dependencies
-COPY package*.json ./
-COPY .Rprofile /root/.Rprofile
+RUN npm install
+RUN make -C py setup
 
-RUN apt-get update && \
-    apt-get install -y python3-pip r-base && \
-    # RScript -e "devtools::install_github('r-lib/systemfonts')" && \
-    # this can be uncommented and changed to make setup if R deps can be resolved
-    npm install && \
-    npm audit fix
-
-# Bundle app source
-COPY . .
+# WIP: Skipping for now, until all system deps are determined and installed.
+# RUN make -C r setup

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# What? A Makefile for running high level development tasks. For finer
+# A Makefile for running high level development tasks. For finer
 # grained tasks see `package.json` and use `npm run <task>`, or the
 # `Makefiles` for each language folder e.g. `py/Makefile`.
 

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,15 @@ checkBindings:
 		fi \
 	done
 
-## Commits just the updated schema bindings
+# Commits just the updated schema bindings
 commitBindings:
 	git commit --only $(PYBINDINGS) $(RBINDINGS) $(RNAMESPACE) -m "chore(Language bindings): Update type bindings"
+
+
+# Build Docker image for development
+build-image:
+	docker build -t stencila/schema .
+
+# Run an interactive shell in Docker container
+run-image: build-image
+	docker run --rm -it -v $$PWD:/code -w /code stencila/schema bash

--- a/README.md
+++ b/README.md
@@ -51,9 +51,7 @@ as a Jupyter Notebook,
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": [
-        "Hello world!"
-      ]
+      "source": ["Hello world!"]
     }
   ]
 }
@@ -68,9 +66,7 @@ as JSON-LD,
   "content": [
     {
       "type": "Paragraph",
-      "content": [
-        "Hello world!"
-      ]
+      "content": ["Hello world!"]
     }
   ]
 }
@@ -91,10 +87,9 @@ This repository does not deal with format conversion per se. Please see [Encoda]
 - [Open Document Format](http://docs.oasis-open.org/office/v1.2/OpenDocument-v1.2-part1.html)
 - [Pandoc Types](https://github.com/jgm/pandoc-types)
 
-
 ### But, sometimes (often) we need more than just names
 
-Despite its name, schema.org does not define strong rules around the _shape_ of data, as say a database schema or XML schema does. All the properties of schema.org types are optional, and although they have "expected types", this is not enforced. In addition, properties can be singular values or array,  but always have a singular name. For example, a `Article` has a `author` property which could be undefined, a string, a `Person` or an `Organization`, or an array of `Person` or `Organization` items.
+Despite its name, schema.org does not define strong rules around the _shape_ of data, as say a database schema or XML schema does. All the properties of schema.org types are optional, and although they have "expected types", this is not enforced. In addition, properties can be singular values or array, but always have a singular name. For example, a `Article` has a `author` property which could be undefined, a string, a `Person` or an `Organization`, or an array of `Person` or `Organization` items.
 
 This flexibility makes a lot of sense for the primary purpose of schema.org: semantic annotation of other content. However, for use as an internal data model, as in Stencila, it can result in a lot of defensive code to check exactly which of these alternatives a property value is. And writing more code than you need to is A Bad Thing™.
 
@@ -147,7 +142,6 @@ With a JSON Schema, we are able to:
 
 JSON can be quite fiddly to write by hand. And JSON Schema lacks a way to easily express parent-child relationships between types. For these reasons, we define types using YAML with custom keywords such as `extends` and generate JSON Schema and ultimately bindings for each language from those.
 
-
 ## 📜 Documentation
 
 Documentation is available at https://schema.stenci.la/.
@@ -161,7 +155,6 @@ Alternatively, you may want to directly consult the type definitions (`*.yaml` f
 A JSON-LD `@context` is generated from the JSON Schema sources and published at https://schema.stenci.la/stencila.jsonld.
 
 Individual files are published for each extension type e.g. https://schema.stenci.la/CodeChunk.jsonld and extension property e.g. https://schema.stenci.la/rowspan.jsonld
-
 
 ### Programming language bindings
 

--- a/docs/developing-docker.md
+++ b/docs/developing-docker.md
@@ -1,0 +1,17 @@
+# Developing with Docker
+
+If you don't want to install npm on your host directly, you can build the provided
+Dockerfile:
+
+```bash
+$ docker build -t stencila/schema .
+```
+
+And then bind your local schemas directory and run commands from the container.
+Here is how we would run `make docs`
+
+```bash
+# Run an interactive shell with your schemas bound
+$ docker run --rm -it -v $PWD/schemas:/code/schemas stencila/schema bash
+$ make docs
+```

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "scripts": {
     "format": "npx prettier --write './**/*.{js,json,md,ts,yaml}'",
     "lint": "npx eslint 'ts/**/*.{js,ts}' --fix",
-    "test": "npm run build:jsonschema && jest",
-    "test:cover": "npm run build:jsonschema && jest --coverage",
+    "test": "npm run build:jsonschema && npm run build:jsonld && npm run build:ts:types && jest",
+    "test:cover": "npm test -- --coverage",
     "build": "npm run build:jsonschema && npm run build:ts:types && npm run build:jsonld && npm run build:py && npm run build:r && npm run build:dist",
     "build:jsonschema": "ts-node ts/schema.ts",
     "build:jsonld": "ts-node ts/bindings/jsonld.ts",

--- a/py/tox.ini
+++ b/py/tox.ini
@@ -1,6 +1,3 @@
-[tox]
-envlist = py36,py37
-
 [testenv]
 deps = pytest
        pytest-cov


### PR DESCRIPTION
@nokome here is the start of work to create a Dockerized development environment! The user should be able to build this container, shell in (with working files mounted with volume) and then run `make docs`, etc. I'm not sure about the R/python/npm dependencies so this is as far as I got. Please push to /update this branch to make it work! This will make it easier to test and add the additional documentation files for #214  

Signed-off-by: vsoch <vsochat@stanford.edu>