### PR TITLE
fix(CodeError): Match required key to property name

### DIFF
--- a/schema/CodeError.schema.yaml
+++ b/schema/CodeError.schema.yaml
@@ -28,4 +28,4 @@ properties:
     description: Stack trace leading up to the error.
     type: string
 required:
-  - message
+  - errorMessage


### PR DESCRIPTION
Otherwise coercion fails https://travis-ci.org/github/stencila/thema/builds/730301506#L1031

The [coerce function in Encoda](https://github.com/stencila/encoda/blob/master/src/util/coerce.ts#L99) does not attempt to read property aliases, and will attempt to read the `message` field on the schema during coercion. As no such property exists it will fail.

Not sure if making Encoda coercion more generous is worthwhile, as it shouldn't affect user-land schema authorship. It only has implications for Schema type definitions.

Going to merge, but would like you to be aware of the above note @nokome.