### PR TITLE
fix(CreativeWork): Move `maintainer` property from `SoftwareSourceCode` to `CreativeWork`.

### DIFF
--- a/schema/CreativeWork.schema.yaml
+++ b/schema/CreativeWork.schema.yaml
@@ -132,6 +132,25 @@ properties:
         - $ref: CreativeWorkTypes
         - type: string
           format: uri
+  maintainers:
+    '@id': schema:maintainer
+    description: The people or organizations who maintain this CreativeWork.
+    $comment: |
+      A maintainer of a Dataset, SoftwareApplication, or other CreativeWork.
+      A maintainer is a Person or Organization that manages contributions to,
+      and/or publication of, some (typically complex) artifact. It is common for
+      distributions of software and data to be based on "upstream" sources.
+      When maintainer is applied to a specific version of something e.g. a particular
+      version or packaging of a Dataset, it is always possible that the upstream
+      source has a different maintainer. The isBasedOn property can be used to
+      indicate such relationships between datasets to make the different maintenance
+      roles clear. Similarly in the case of software, a package may have dedicated
+      maintainers working on integration into software distributions such as Ubuntu,
+      as well as upstream maintainers of the underlying work.
+    type: array
+    items:
+      - $ref: Organization
+      - $ref: Person
   parts:
     # The name "parts" seems more intuitive for users and developers than schema.orgs's "hasParts".
     # We provide the latter as an alias.

--- a/schema/SoftwareSourceCode.schema.yaml
+++ b/schema/SoftwareSourceCode.schema.yaml
@@ -19,14 +19,6 @@ properties:
     description: |
       What type of code sample: full (compile ready) solution, code snippet, inline code, scripts, template.
     type: string
-  maintainers:
-    '@id': codemeta:maintainer
-    description: |
-      The people or organizations who maintain the software.
-    type: array
-    items:
-      - $ref: Organization
-      - $ref: Person
   programmingLanguage:
     '@id': schema:programmingLanguage
     description: |

--- a/ts/util/jsonld.test.ts
+++ b/ts/util/jsonld.test.ts
@@ -29,10 +29,6 @@ test('jsonLdTermUrl', () => {
   expect(jsonLdTermUrl('Article')).toEqual('http://schema.org/Article')
   expect(jsonLdTermUrl('authors')).toEqual('http://schema.org/author')
 
-  expect(jsonLdTermUrl('maintainers')).toEqual(
-    'http://doi.org/10.5063/schema/codemeta-2.0#maintainer'
-  )
-
   expect(jsonLdTermUrl('foo')).toBeUndefined()
 })
 
@@ -43,8 +39,4 @@ test('jsonLdTermName', () => {
 
   expect(jsonLdTermName('http://schema.org/Article')).toEqual('Article')
   expect(jsonLdTermName('http://schema.org/author')).toEqual('authors')
-
-  expect(
-    jsonLdTermName('http://doi.org/10.5063/schema/codemeta-2.0#maintainer')
-  ).toEqual('maintainers')
 })

--- a/ts/util/microdata.test.ts
+++ b/ts/util/microdata.test.ts
@@ -126,8 +126,6 @@ test('microdataItemprop', () => {
   expect(microdataItemprop('authors')).toEqual(['schema', 'author'])
   expect(microdataItemprop('references')).toEqual(['schema', 'citation'])
 
-  expect(microdataItemprop('maintainers')).toEqual(['codemeta', 'maintainer'])
-
   expect(microdataItemprop('foo')).toEqual([undefined, undefined])
 })
 


### PR DESCRIPTION
Maintainer is now a schema.org property on https://schema.org/CreativeWork.
