### PR TITLE
fix(Claim): Treat label or title as InlineContent

### DIFF
--- a/py/stencila/schema/types.py
+++ b/py/stencila/schema/types.py
@@ -971,7 +971,7 @@ class Claim(CreativeWork):
     claimType: Optional["EClaimType"] = None
     """Kind of the claim."""
 
-    label: Optional[str] = None
+    label: Optional[Array["InlineContent"]] = None
     """A short label for the claim."""
 
 
@@ -998,7 +998,7 @@ class Claim(CreativeWork):
         images: Optional[Array[Union["ImageObject", str]]] = None,
         isPartOf: Optional["CreativeWorkTypes"] = None,
         keywords: Optional[Array[str]] = None,
-        label: Optional[str] = None,
+        label: Optional[Array["InlineContent"]] = None,
         licenses: Optional[Array[Union["CreativeWorkTypes", str]]] = None,
         maintainers: Optional[Array[Union["Person", "Organization"]]] = None,
         meta: Optional[Dict[str, Any]] = None,

--- a/r/R/types.R
+++ b/r/R/types.R
@@ -1013,7 +1013,7 @@ Claim <- function(
   self$type <- as_scalar("Claim")
   self[["content"]] <- check_property("Claim", "content", TRUE, missing(content), Array(BlockContent), content)
   self[["claimType"]] <- check_property("Claim", "claimType", FALSE, missing(claimType), Enum("Statement", "Theorem", "Lemma", "Proof", "Postulate", "Hypothesis", "Proposition", "Corollary"), claimType)
-  self[["label"]] <- check_property("Claim", "label", FALSE, missing(label), "character", label)
+  self[["label"]] <- check_property("Claim", "label", FALSE, missing(label), Array(InlineContent), label)
   class(self) <- c(class(self), "Claim")
   self
 }

--- a/schema/Claim.schema.yaml
+++ b/schema/Claim.schema.yaml
@@ -36,6 +36,8 @@ properties:
   label:
     '@id': stencila:label
     description: A short label for the claim.
-    type: string
+    type: array
+    items:
+      $ref: InlineContent
 required:
   - content


### PR DESCRIPTION
A minor update to the Claim spec. Like heading they could contain formatting like `italic` or references.